### PR TITLE
Fix README clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Meow Namester is a web application that helps you pick the perfect cat name thro
 1. Clone the repository
 
    ```bash
-   git clone https://github.com/yourusername/meow-namester-react.git
+   git clone https://github.com/guitarbeat/meow-namester-react.git
    cd meow-namester-react
    ```
 2. Install dependencies


### PR DESCRIPTION
## Summary
- point installation instructions to actual GitHub repo URL

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411a5d18188327a811c353cf729653

## Summary by Sourcery

Documentation:
- Correct the git clone instruction in README to use guitarbeat/meow-namester-react