### PR TITLE
Add lint configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-recess-order"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ The app will be available at `http://localhost:3000`.
   - `REACT_APP_SUPABASE_ANON_KEY`
 
 If additional packages are missing, run `npm install` to ensure all dependencies from `package.json` are installed.
+
+## Linting
+
+Run ESLint on the JavaScript and JSX files:
+
+```bash
+npm run lint:js
+```
+
+Run Stylelint on the CSS files:
+
+```bash
+npm run lint:css
+```


### PR DESCRIPTION
## Summary
- add ESLint configuration extending react standards
- add Stylelint configuration for standard and recess order
- document lint commands

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run lint:js` *(fails: 235 errors, 9 warnings)*
- `npm run lint:css` *(fails: 1078 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68411a6768cc8327b0ddcacf9ed11a6d