### PR TITLE
Add React Testing Library with sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-private-property-in-object": "^7.21.11",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "eslint": "^8.56.0",

--- a/src/components/LoadingSpinner/LoadingSpinner.test.js
+++ b/src/components/LoadingSpinner/LoadingSpinner.test.js
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import LoadingSpinner from './LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+  it('renders loading text when provided', () => {
+    render(<LoadingSpinner text="Loading..." />);
+    const spinner = screen.getByRole('status');
+    expect(spinner).toBeInTheDocument();
+    expect(screen.getAllByText('Loading...').length).toBeGreaterThan(0);
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add React Testing Library dependencies
- configure Jest in `setupTests.js`
- add a basic test for `LoadingSpinner`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68411a933a608327b24103f9b53567f0