### PR TITLE
Remove calculateUserStats function

### DIFF
--- a/src/utils/adminActions.js
+++ b/src/utils/adminActions.js
@@ -32,23 +32,3 @@ export const formatTimestamp = (timestamp) => {
   return date.toLocaleDateString();
 };
 
-export const calculateUserStats = (ratings) => {
-  if (!ratings?.length) {
-    return {
-      avgRating: 0,
-      totalGames: 0,
-      winRate: 0,
-    };
-  }
-
-  const totalGames = ratings.reduce((sum, r) => sum + (r.wins + r.losses), 0);
-  const totalWins = ratings.reduce((sum, r) => sum + r.wins, 0);
-
-  return {
-    avgRating: Math.round(
-      ratings.reduce((sum, r) => sum + (r.rating || 1500), 0) / ratings.length,
-    ),
-    totalGames,
-    winRate: totalGames ? Math.round((totalWins / totalGames) * 100) : 0,
-  };
-};


### PR DESCRIPTION
## Summary
- delete `calculateUserStats` util

## Testing
- `npm test -- -u`
- `npm run lint:js` *(fails: many errors)*
- `npm run lint:css` *(fails: many errors)*

------
https://chatgpt.com/codex/tasks/task_e_68412a410cd8832784be13c995492399

## Summary by Sourcery

Chores:
- Delete the calculateUserStats function and its associated code from src/utils/adminActions.js