### PR TITLE
Fix badge composition casing

### DIFF
--- a/src/components/Bracket/Bracket.module.css
+++ b/src/components/Bracket/Bracket.module.css
@@ -198,13 +198,15 @@
 }
 
 .tieBadge {
-  composes: winnerbadge;
+  /* stylelint-disable-next-line value-keyword-case */
+  composes: winnerBadge;
   color: var(--success-500);
   background: var(--success-50);
 }
 
 .skipBadge {
-  composes: winnerbadge;
+  /* stylelint-disable-next-line value-keyword-case */
+  composes: winnerBadge;
   color: var(--warning-500);
   background: var(--warning-50);
 }


### PR DESCRIPTION
## Summary
- fix casing of winnerBadge in bracket CSS to resolve build error
- add stylelint suppression to preserve winnerBadge composition

## Testing
- `npm run lint:js`
- `npm run lint:css`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d05ce5c8327a130450585fac0c6