### PR TITLE
Handle missing Supabase config to allow app to load

### DIFF
--- a/src/supabase/supabaseClient.js
+++ b/src/supabase/supabaseClient.js
@@ -15,13 +15,20 @@ const supabaseAnonKey =
   import.meta.env.VITE_SUPABASE_ANON_KEY ||
   import.meta.env.BAG_NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
+// Only create the Supabase client if the required environment variables are present
+// Otherwise export `null` so the application can still render without Supabase
+let supabase = null;
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(
-    'Missing Supabase environment variables. Please check your .env file. Required: VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY (or BAG_NEXT_PUBLIC_SUPABASE_URL and BAG_NEXT_PUBLIC_SUPABASE_ANON_KEY)'
-  );
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      'Missing Supabase environment variables. Supabase features are disabled.'
+    );
+  }
+} else {
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export { supabase };
 
 // ===== CORE API FUNCTIONS =====
 


### PR DESCRIPTION
## Summary
- Avoid throwing when Supabase credentials are missing and export a null client instead
- Guard user session initialization and login when Supabase isn't configured, with helpful warnings

## Testing
- `npm test`
- `npm run build`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_68ad841e04f08327b1edf37dd97a9858