### PR TITLE
Fix CSS module composition causing Vercel build failure

### DIFF
--- a/src/components/Profile/Profile.module.css
+++ b/src/components/Profile/Profile.module.css
@@ -691,7 +691,7 @@
   border-color: var(--primary-300);
 }
 
-.userSelectionButton.selectedUser {
+.selectedUser {
   composes: btn btn--primary from "../../styles/global.css";
 }
 


### PR DESCRIPTION
## Summary
- replace invalid `.userSelectionButton.selectedUser` compose with separate `.selectedUser` class

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af5b1f6b4883279a516d04712a7fcb