### PR TITLE
Debug and rename code elements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -149,11 +149,6 @@ function App() {
   // * Handle tournament setup
   const handleTournamentSetup = useCallback(
     (names) => {
-      console.log(
-        '[DEV] 🎮 App: handleTournamentSetup called with names:',
-        names
-      );
-
       // * Only set loading if we don't already have names
       if (!tournament.names) {
         tournamentActions.setLoading(true);
@@ -163,7 +158,6 @@ function App() {
         names,
         tournament.ratings
       );
-      console.log('[DEV] 🎮 App: Processed names:', processedNames);
 
       tournamentActions.setNames(processedNames);
       // Ensure we are on the tournament view after starting

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,15 +7,15 @@ This directory contains all testing-related files and utilities for the Meow Nam
 ```
 tests/
 ├── README.md           # This file - testing overview
-├── debug/              # Debug testing utilities
-│   └── README.md      # Debug testing guidelines
+├── utilities/           # Development testing utilities
+│   └── README.md      # Development utilities guidelines
 ├── unit/               # Unit tests (future)
 └── integration/        # Integration tests (future)
 ```
 
 ## **🧪 Testing Types**
 
-### **Debug Testing** (`tests/debug/`)
+### **Development Utilities** (`tests/utilities/`)
 - **Purpose:** Temporary debugging and troubleshooting
 - **Use Case:** When debugging Supabase connections, database issues, or other problems
 - **Files:** HTML test pages, SQL queries, JavaScript debug scripts
@@ -39,7 +39,7 @@ tests/
 
 ## **📝 Testing Guidelines**
 
-1. **Debug Tests:** Keep in `tests/debug/` and clean up after use
+1. **Development Utilities:** Keep in `tests/utilities/` and clean up after use
 2. **Unit Tests:** Write for all new components and functions
 3. **Integration Tests:** Write for critical user workflows
 4. **Coverage:** Aim for >80% code coverage

--- a/tests/utilities/README.md
+++ b/tests/utilities/README.md
@@ -1,14 +1,14 @@
-# Debug Testing Directory
+# Development Utilities Directory
 
 This directory contains debugging and testing utilities for development and troubleshooting.
 
 ## **📁 Directory Structure**
 
-- `tests/debug/` - Debug testing utilities
+- `tests/utilities/` - Development testing utilities
 - `tests/unit/` - Unit tests (if needed)
 - `tests/integration/` - Integration tests (if needed)
 
-## **🔧 Debug Utilities**
+## **🔧 Development Utilities**
 
 ### **Supabase Connection Testing**
 When debugging Supabase connection issues, create temporary test files here:
@@ -53,7 +53,7 @@ WHERE table_schema = 'public' AND table_name LIKE 'cat_%';
 1. **Isolation:** Keep debug files separate from production code
 2. **Documentation:** Document what each debug file tests
 3. **Cleanup:** Remove debug files when no longer needed
-4. **Version Control:** Add `tests/debug/*.tmp` to `.gitignore` if needed
+4. **Version Control:** Add `tests/utilities/*.tmp` to `.gitignore` if needed
 
 ---
 


### PR DESCRIPTION
Rename `tests/debug` to `tests/utilities` and remove debug `console.log` statements to improve clarity and clean up the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-368ea9c4-9db3-4a06-9759-dc028aafd380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-368ea9c4-9db3-4a06-9759-dc028aafd380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

