### PR TITLE
Add spaces between welcome screen names

### DIFF
--- a/src/shared/services/tournamentService.js
+++ b/src/shared/services/tournamentService.js
@@ -282,7 +282,7 @@ export class TournamentService {
       const sortedNames = ratingsData
         .map(item => item.cat_name_options?.name)
         .filter(name => name) // Remove any null/undefined names
-        .join('');
+        .join(' ');
 
       return sortedNames || 'Mystery Cat';
     } catch (error) {


### PR DESCRIPTION
Add spaces between names in the welcome screen's generated cat name for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5dbdf22-87a3-4546-9c5b-c3522a8b57f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5dbdf22-87a3-4546-9c5b-c3522a8b57f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Enhancements:
- Join cat name options with spaces instead of concatenating them without separators.