### PR TITLE
Remove welcome tournament text

### DIFF
--- a/src/shared/components/WelcomeScreen/WelcomeScreen.jsx
+++ b/src/shared/components/WelcomeScreen/WelcomeScreen.jsx
@@ -171,9 +171,6 @@ function WelcomeScreen({ onContinue, catName, nameStats = [], isTransitioning = 
             <span className={styles.stepNumber}>1</span>
             <span className={styles.stepText}>Meet Your Cat</span>
           </div>
-          <h1 className={styles.welcomeTitle}>
-            Welcome to the Cat Name Tournament!
-          </h1>
 
           <picture>
             <source type="image/avif" srcSet="/assets/images/IMG_5071.avif" />


### PR DESCRIPTION
Remove "Welcome to the Cat Name Tournament!" from the welcome screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-09c002bb-76a9-47c6-b8f8-3e32b38ffcda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09c002bb-76a9-47c6-b8f8-3e32b38ffcda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

