### PR TITLE
Expand welcome screen to full width

### DIFF
--- a/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
+++ b/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
@@ -216,7 +216,7 @@
   gap: clamp(1.5rem, 3vw, 2.5rem);
   width: 100%;
   min-width: 320px;
-  max-width: min(90vw, 600px);
+  max-width: 100%;
   max-height: 90vh;
   padding: clamp(1rem, 4vw, 3rem);
   overflow-y: auto;
@@ -698,7 +698,8 @@
 @media (width >= 1400px) {
   .contentContainer {
     gap: clamp(2rem, 4vw, 3rem);
-    max-width: min(80vw, 800px);
+    max-width: 100%;
+    padding: clamp(2rem, 5vw, 4rem);
   }
 
   .catImage {
@@ -710,7 +711,7 @@
 /* Tablets and medium screens */
 @media (width <= 1024px) and (width >= 769px) {
   .contentContainer {
-    max-width: min(85vw, 550px);
+    max-width: 100%;
     padding: clamp(1.5rem, 3vw, 2.5rem);
   }
 }
@@ -719,7 +720,7 @@
 @media (width <= 768px) {
   .contentContainer {
     gap: clamp(1.25rem, 2.5vw, 2rem);
-    max-width: min(90vw, 500px);
+    max-width: 100%;
     padding: clamp(1rem, 3vw, 2rem);
   }
 }
@@ -809,7 +810,7 @@
   .contentContainer {
     gap: clamp(1.5rem, 4vw, 2.5rem);
     padding: clamp(1.25rem, 4vw, 2.5rem);
-    max-width: min(95vw, 480px);
+    max-width: 100%;
   }
 
   /* Enhanced mobile visual hierarchy */
@@ -858,7 +859,7 @@
 @media (width <= 480px) {
   .contentContainer {
     gap: clamp(1.75rem, 4vw, 2.25rem);
-    max-width: 96vw;
+    max-width: 100%;
     padding: clamp(1.5rem, 4vw, 2.25rem);
     margin: 0 auto;
   }
@@ -1072,7 +1073,7 @@
 @media (width <= 320px) {
   .contentContainer {
     gap: 1.25rem;
-    max-width: 98vw;
+    max-width: 100%;
     padding: 1rem;
   }
 
@@ -1376,6 +1377,7 @@
   .contentContainer {
     gap: clamp(1.5rem, 4vw, 2rem);
     padding: clamp(1.25rem, 4vw, 2rem);
+    max-width: 100%;
   }
 
   .mainContent {


### PR DESCRIPTION
Allow the welcome screen content to take up the full available width by removing `max-width` constraints.

---
<a href="https://cursor.com/background-agent?bcId=bc-96108bb2-f9c1-41af-a1d5-c0f996fcbb4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96108bb2-f9c1-41af-a1d5-c0f996fcbb4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

