### PR TITLE
Fix welcome screen card top visibility

### DIFF
--- a/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
+++ b/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
@@ -185,7 +185,7 @@
   min-width: 320px;
   max-width: 100%;
   min-height: 100vh;
-  padding: clamp(var(--ws-space-lg), 3vw, var(--ws-space-3xl)) clamp(var(--ws-space-sm), 2vw, var(--ws-space-2xl));
+  padding: clamp(var(--ws-space-3xl), 5vw, var(--ws-space-4xl)) clamp(var(--ws-space-lg), 3vw, var(--ws-space-3xl));
   overflow: auto;
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
@@ -244,7 +244,7 @@
 
 .rotatedCard {
   width: min(95vw, 700px);
-  margin: 0 auto;
+  margin: clamp(var(--ws-space-lg), 3vw, var(--ws-space-2xl)) auto;
   box-shadow: rgba(0, 0, 0, 0.4) 0 2px 10px, inset rgba(0, 0, 0, 0.2) 0 0 50px;
   border-radius: 1em;
   padding: 0;
@@ -898,7 +898,7 @@
 
   .contentContainer {
     max-height: none;
-    padding: clamp(var(--ws-space-sm), 1.5vw, var(--ws-space-lg));
+    padding: clamp(var(--ws-space-2xl), 4vw, var(--ws-space-3xl)) clamp(var(--ws-space-md), 2vw, var(--ws-space-xl));
     overflow: visible;
     overscroll-behavior: contain;
     scroll-padding-top: var(--ws-space-sm);
@@ -934,7 +934,7 @@
 /* Mobile Portrait (≤480px) */
 @media (width <= 480px) {
   .contentContainer {
-    padding: clamp(var(--ws-space-md), 2vw, var(--ws-space-xl));
+    padding: clamp(var(--ws-space-xl), 3vw, var(--ws-space-2xl)) clamp(var(--ws-space-sm), 1.5vw, var(--ws-space-lg));
   }
 
   .rotatedCard {
@@ -974,7 +974,7 @@
 
   .contentContainer {
     max-height: none;
-    padding: var(--ws-space-md);
+    padding: clamp(var(--ws-space-lg), 2.5vw, var(--ws-space-xl)) var(--ws-space-sm);
     overflow: visible;
   }
 
@@ -1026,7 +1026,7 @@
 
   .contentContainer {
     max-height: none;
-    padding: clamp(var(--ws-space-md), 1.5vh, var(--ws-space-lg));
+    padding: clamp(var(--ws-space-xl), 2.5vh, var(--ws-space-2xl)) clamp(var(--ws-space-sm), 1.5vw, var(--ws-space-lg));
     overflow: visible;
   }
 


### PR DESCRIPTION
Increase padding and margin in the welcome screen to prevent the top of the rotated card from being clipped.

The `transform: rotate(-3deg)` on the `.rotatedCard` caused its top edge to extend beyond the `contentContainer`'s visible area, resulting in clipping. Adjusting the padding of the container and adding margin to the card provides sufficient space for the rotated element across various screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-82491e1f-06af-4338-9e6e-ca052db16fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82491e1f-06af-4338-9e6e-ca052db16fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

