### PR TITLE
Debug name card text color on welcome screen

### DIFF
--- a/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
+++ b/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
@@ -1269,7 +1269,7 @@
 }
 
 :global(.dark-theme) .catNameText {
-  color: var(--ws-light-text);
+  color: #000000;
 }
 
 :global(.dark-theme) .explanationText {


### PR DESCRIPTION
Change cat name text color to black in dark theme to ensure readability against light backgrounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ae131dc-8532-45a0-9715-c44413fa320e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ae131dc-8532-45a0-9715-c44413fa320e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

