### PR TITLE
Remove duplicate welcome screen name cards

### DIFF
--- a/src/shared/services/tournamentService.js
+++ b/src/shared/services/tournamentService.js
@@ -415,7 +415,7 @@ export class TournamentService {
       }
 
       // Process and return the data with stats
-      return visibleNames.map((name, index) => {
+      const processedNames = visibleNames.map((name, index) => {
         const ratingData = ratingsMap.get(name.id);
 
         if (ratingData) {
@@ -454,6 +454,21 @@ export class TournamentService {
           };
         }
       });
+
+      // Remove any potential duplicates by name (safety check)
+      const uniqueNames = processedNames.reduce((acc, name) => {
+        const existing = acc.find(item => item.name === name.name);
+        if (!existing) {
+          acc.push(name);
+        } else if (name.rating > existing.rating) {
+          // Keep the one with higher rating
+          const index = acc.indexOf(existing);
+          acc[index] = name;
+        }
+        return acc;
+      }, []);
+
+      return uniqueNames;
     } catch (error) {
       console.error('Error fetching cat name stats:', error);
       return [];


### PR DESCRIPTION
Remove duplicate name cards from the welcome screen by enhancing data source deduplication and improving name matching and overlap detection logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce3be357-b9bb-4ede-8f8e-198baeb86c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce3be357-b9bb-4ede-8f8e-198baeb86c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

