### PR TITLE
Remove welcome screen name tilt

### DIFF
--- a/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
+++ b/src/shared/components/WelcomeScreen/WelcomeScreen.module.css
@@ -442,7 +442,7 @@
   border-radius: 1em;
   padding: 0;
   background-color: #fff;
-  transform: rotate(-3deg);
+  transform: none;
   transition: transform 0.3s ease;
   position: relative;
   z-index: 1;
@@ -450,7 +450,7 @@
 }
 
 .rotatedCard:hover {
-  transform: rotate(-1deg) scale(1.02);
+  transform: scale(1.02);
 }
 
 .cardHeader {
@@ -480,7 +480,7 @@
   font-family: 'Waiting for the Sunrise', cursive;
   color: #000000;
   font-size: clamp(0.9em, 2.2vw, 1.3em);
-  transform: rotate(-3deg);
+  transform: none;
   line-height: 1.1;
   padding: 0.6em 1em;
   display: flex;
@@ -1193,11 +1193,11 @@
   .rotatedCard {
     width: min(90vw, 600px);
     margin: 0 auto;
-    transform: rotate(-2deg);
+    transform: none;
   }
 
   .rotatedCard:hover {
-    transform: rotate(0deg) scale(1.02);
+    transform: scale(1.02);
   }
 
   .headerText {
@@ -1207,7 +1207,7 @@
 
   .catNameContainer {
     font-size: clamp(0.8em, 2.2vw, 1.2em);
-    transform: rotate(-2deg);
+    transform: none;
     gap: 0.02em;
   }
 
@@ -1225,11 +1225,11 @@
   .rotatedCard {
     width: min(85vw, 500px);
     margin: 0 auto;
-    transform: rotate(-1.5deg);
+    transform: none;
   }
 
   .rotatedCard:hover {
-    transform: rotate(0deg) scale(1.02);
+    transform: scale(1.02);
   }
 
   .headerText {
@@ -1239,7 +1239,7 @@
 
   .catNameContainer {
     font-size: clamp(0.7em, 2vw, 1.1em);
-    transform: rotate(-1.5deg);
+    transform: none;
     gap: 0.01em;
   }
 
@@ -1269,11 +1269,11 @@
   .rotatedCard {
     width: min(80vw, 400px);
     margin: 0 auto;
-    transform: rotate(-1deg);
+    transform: none;
   }
 
   .rotatedCard:hover {
-    transform: rotate(0deg) scale(1.02);
+    transform: scale(1.02);
   }
 
   .headerText {
@@ -1283,7 +1283,7 @@
 
   .catNameContainer {
     font-size: clamp(0.6em, 1.8vw, 1em);
-    transform: rotate(-1deg);
+    transform: none;
     gap: 0.005em;
     padding: 0.02em 0.1em;
   }
@@ -1352,11 +1352,11 @@
   .rotatedCard {
     width: min(75vw, 600px);
     margin: 0 auto;
-    transform: rotate(-2deg);
+    transform: none;
   }
 
   .rotatedCard:hover {
-    transform: rotate(0deg) scale(1.02);
+    transform: scale(1.02);
   }
 
   .headerText {
@@ -1366,7 +1366,7 @@
 
   .catNameContainer {
     font-size: clamp(0.9em, 2.5vw, 1.4em);
-    transform: rotate(-2deg);
+    transform: none;
     gap: 0.03em;
   }
 
@@ -1383,16 +1383,16 @@
 
   .rotatedCard {
     margin: 0 auto;
-    transform: rotate(-2deg);
+    transform: none;
   }
 
   .rotatedCard:hover {
-    transform: rotate(0deg) scale(1.02);
+    transform: scale(1.02);
   }
 
   .catNameContainer {
     font-size: clamp(0.8em, 2.2vw, 1.2em);
-    transform: rotate(-2deg);
+    transform: none;
     gap: 0.02em;
   }
 }


### PR DESCRIPTION
Remove tilt/rotation effects from the names displayed on the welcome screen.

This PR addresses the user's request to have the names appear straight and level, by setting `transform: none` for the `.rotatedCard` and `.catNameContainer` elements, and adjusting hover effects and responsive breakpoints accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-232063b0-c998-4863-b9de-3179bd7d407f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-232063b0-c998-4863-b9de-3179bd7d407f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

