### PR TITLE
Remove welcome screen name duplication

### DIFF
--- a/src/shared/components/WelcomeScreen/WelcomeScreen.jsx
+++ b/src/shared/components/WelcomeScreen/WelcomeScreen.jsx
@@ -306,7 +306,9 @@ function WelcomeScreen({
           });
         }
         
-        searchIndex = index + 1; // Move past this match to find overlapping ones
+        // Move past the entire match to avoid finding overlapping substrings
+        // (e.g., if catName is "Fluffy" and we found "Fluff", don't also find "luff")
+        searchIndex = index + stat.name.length;
       }
     }
 


### PR DESCRIPTION
Fix name duplication in the welcome screen by adjusting the search index to move past the entire matched name.

The previous logic `searchIndex = index + 1` caused issues where, after finding a name (e.g., 'Fluff' in 'Fluffy'), the search would continue from the next character, potentially finding a substring (e.g., 'luff') as a new match. This led to duplicate or overlapping name entries. The fix ensures the search continues *after* the entire matched name, preventing these erroneous duplicates.

---
<a href="https://cursor.com/background-agent?bcId=bc-111f56f8-3cbb-46de-bdf6-05fbd406f6db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-111f56f8-3cbb-46de-bdf6-05fbd406f6db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

