### PR TITLE
Revert styling changes

### DIFF
--- a/config/vite.config.mjs
+++ b/config/vite.config.mjs
@@ -55,22 +55,26 @@ export default defineConfig({
     css: {
         postcss: {
             plugins: [
-                purgecss.default({
-                    content: ['./src/**/*.{js,jsx,ts,tsx}'],
-                    safelist: [
-                        'welcome-page',
-                        'dark-theme',
-                        'light-theme',
-                        'cat-background',
-                        'cat-background__stars',
-                        'cat-background__nebula',
-                        'cat-background__floating-cats',
-                        'cat-background__cat',
-                        'skip-link',
-                        'main-content',
-                        'global-loading-overlay'
+                ...(process.env.NODE_ENV === 'production'
+                    ? [
+                        purgecss.default({
+                            content: ['./src/**/*.{js,jsx,ts,tsx}'],
+                            safelist: [
+                                'welcome-page',
+                                'dark-theme',
+                                'light-theme',
+                                'cat-background',
+                                'cat-background__stars',
+                                'cat-background__nebula',
+                                'cat-background__floating-cats',
+                                'cat-background__cat',
+                                'skip-link',
+                                'main-content',
+                                'global-loading-overlay'
+                            ]
+                        })
                     ]
-                })
+                    : [])
             ]
         }
     },


### PR DESCRIPTION
Gate PurgeCSS to run only in production to prevent it from stripping styles during development.

---
<a href="https://cursor.com/background-agent?bcId=bc-41f2eaa7-905d-4bf7-9593-b6c869bd0df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41f2eaa7-905d-4bf7-9593-b6c869bd0df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

