### PR TITLE
chore: remove informational logs from tournament handlers and flow

### DIFF
--- a/src/features/tournament/hooks/useTournamentHandlers.ts
+++ b/src/features/tournament/hooks/useTournamentHandlers.ts
@@ -29,9 +29,7 @@ export function useTournamentHandlers({ userName, tournamentActions }: UseTourna
                         ratingsAPI
                                 .saveRatings(uName, ratings)
                                 .then(async (result) => {
-                                        if (result?.success) {
-                                                console.log(`Saved ${result.count} ratings to database`);
-                                        } else {
+                                        if (!result?.success) {
                                                 await enqueueRatingsMutation(records);
                                                 console.warn("Ratings save failed; queued for offline sync");
                                         }

--- a/src/features/tournament/modes/TournamentFlow.tsx
+++ b/src/features/tournament/modes/TournamentFlow.tsx
@@ -30,9 +30,7 @@ export default function TournamentFlow() {
                         ratingsAPI
                                 .saveRatings(userName, ratingsSnapshot)
                                 .then(async (result) => {
-                                        if (result?.success) {
-                                                console.log(`Successfully saved ${result.count} ratings to database`);
-                                        } else {
+                                        if (!result?.success) {
                                                 // Save failed (e.g. offline) — enqueue for later sync
                                                 const records = Object.entries(ratingsSnapshot).map(([nameId, data]) => ({
                                                         name_id: nameId,


### PR DESCRIPTION
chore: remove informational logs from tournament handlers and flow

Removed informational `console.log` statements from `src/features/tournament/hooks/useTournamentHandlers.ts` and `src/features/tournament/modes/TournamentFlow.tsx`. The logic was simplified by inverting the success check to directly handle failures/warnings, improving code readability.

- Refactored `useTournamentHandlers.ts` to remove success log.
- Refactored `TournamentFlow.tsx` to remove success log.
- Maintained critical warning logs for offline synchronization.

---
Created from Jules session `sessions/10830097289306643074`
Jules URL: https://jules.google.com/session/10830097289306643074

## Summary by Sourcery

Enhancements:
- Simplify tournament rating save handlers by inverting the success check to focus on failure paths and offline queuing behavior.