### PR TITLE
perf: optimize buildNameCardImages loop

### DIFF
--- a/src/features/tournament/utils/nameSelection.ts
+++ b/src/features/tournament/utils/nameSelection.ts
@@ -39,15 +39,18 @@ export function buildNameCardImages(names: readonly NameItem[]): {
 	catImages: string[];
 	catImageById: Map<IdType, string>;
 } {
-	const catImages = names.map((nameItem) => getRandomCatImage(nameItem.id, CAT_IMAGES));
+	const count = names.length;
+	const catImages = new Array<string>(count);
 	const catImageById = new Map<IdType, string>();
 
-	names.forEach((nameItem, index) => {
-		const image = catImages[index];
+	for (let i = 0; i < count; i++) {
+		const nameItem = names[i];
+		const image = getRandomCatImage(nameItem.id, CAT_IMAGES);
+		catImages[i] = image;
 		if (image) {
 			catImageById.set(nameItem.id, image);
 		}
-	});
+	}
 
 	return { catImages, catImageById };
 }


### PR DESCRIPTION
perf: optimize buildNameCardImages loop

Refactored buildNameCardImages to use a single for loop instead of chained .map() and .forEach() calls. This reduces the number of iterations and avoids the creation of an intermediate array, improving performance. Pre-allocated the results array for better memory efficiency.

---
Created from Jules session `sessions/15795169029495649916`
Jules URL: https://jules.google.com/session/15795169029495649916

## Summary by Sourcery

Enhancements:
- Refactor buildNameCardImages to use a single indexed loop with preallocated result array and direct map population for better performance and memory usage.