### PR TITLE
security: replace hardcoded password with environment variable

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -1,6 +1,7 @@
 # Static-only deployment (no /api backend): required for Supabase fallback
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-public-key
+VITE_SUPABASE_DEMO_PASSWORD=demo-password-for-name-login
 
 # Optional: set only if you have a separate API host.
 # If unset, the app defaults to /api.

--- a/src/shared/services/supabase/authAdapter.ts
+++ b/src/shared/services/supabase/authAdapter.ts
@@ -93,9 +93,18 @@ export const supabaseAuthAdapter: AuthAdapter = {
 
 			// Sign in with Supabase
 			const sanitizedEmail = `${sanitizeNameForEmail(name)}@demo.local`;
+			const demoPassword = import.meta.env.VITE_SUPABASE_DEMO_PASSWORD;
+
+			if (!demoPassword) {
+				console.error(
+					"[Auth] VITE_SUPABASE_DEMO_PASSWORD is not set. Demo login will not work.",
+				);
+				return false;
+			}
+
 			const { data, error } = await client.auth.signInWithPassword({
 				email: sanitizedEmail,
-				password: "demo-password", // Demo password
+				password: demoPassword,
 			});
 
 			if (error) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
 	readonly VITE_SENTRY_DSN?: string;
 	readonly VITE_APP_VERSION?: string;
 	readonly VITE_WEBSOCKET_URL?: string;
+	readonly VITE_SUPABASE_DEMO_PASSWORD?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
security: replace hardcoded password with environment variable

---
Created from Jules session `sessions/4203647542736777732`
Jules URL: https://jules.google.com/session/4203647542736777732

## Summary by Sourcery

Replace the hardcoded Supabase demo password with a configurable environment variable and add its type definition.

Enhancements:
- Use a VITE_SUPABASE_DEMO_PASSWORD environment variable for Supabase demo sign-in and log a clear error when it is missing.
- Declare the VITE_SUPABASE_DEMO_PASSWORD field in the Vite environment type definitions for better type safety.