### PR TITLE
fix: remove leftover console logs in TournamentFlow

### DIFF
--- a/src/features/tournament/modes/TournamentFlow.tsx
+++ b/src/features/tournament/modes/TournamentFlow.tsx
@@ -67,16 +67,9 @@ export default function TournamentFlow() {
                                 {} as Record<string, { rating: number; wins: number; losses: number }>,
                         );
 
-                        mutateAsyncRef.current({ userId, ratings: ratingsWithStats })
-                                .then((result) => {
-                                        if (result?.success) {
-                                                console.log(`Successfully saved ${result.count} ratings to database`);
-                                        }
-                                })
-                                .catch((_error) => {
-                                        // Error is already logged by ratingsAPI with context
-                                        console.warn("Tournament ratings save failed — ratings were not persisted");
-                                });
+                        mutateAsyncRef.current({ userId, ratings: ratingsWithStats }).catch(() => {
+                                // Error is already logged by ratingsAPI with context
+                        });
                 }
         }, [
                 tournament.isComplete,


### PR DESCRIPTION
fix: remove leftover console logs in TournamentFlow

- Removed success console.log in TournamentFlow
- Removed failure console.warn in TournamentFlow
- Added silent catch block with comment to maintain promise handling and Biome compliance

---
Created from Jules session `sessions/5152056931392445130`
Jules URL: https://jules.google.com/session/5152056931392445130

## Summary by Sourcery

Clean up tournament ratings persistence flow by removing noisy console logging while preserving error handling behavior.

Bug Fixes:
- Eliminate leftover success and warning console logs from the tournament ratings save flow to avoid redundant logging and console noise.

Enhancements:
- Simplify the tournament ratings save promise handling with a silent catch block that relies on existing API-level error logging.