### PR TITLE
🧪 test(analytics): improve test coverage for local environments

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,8 +1,0 @@
-🎯 **What:** The testing gap addressed
-The `shouldEnableAnalytics` function in `src/app/analytics.ts` contained a few missing edge cases for testing. The existing test only covered `localhost` and `127.0.0.1`.
-
-📊 **Coverage:** What scenarios are now tested
-Added coverage for the remaining local analytics hosts that block analytics on preview deployments: `0.0.0.0` and `::1`.
-
-✨ **Result:** The improvement in test coverage
-The `src/app/analytics.ts` file now has 100% test coverage for all of the hardcoded non-production hosts within `LOCAL_ANALYTICS_HOSTS`.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,8 @@
+🎯 **What:** The testing gap addressed
+The `shouldEnableAnalytics` function in `src/app/analytics.ts` contained a few missing edge cases for testing. The existing test only covered `localhost` and `127.0.0.1`.
+
+📊 **Coverage:** What scenarios are now tested
+Added coverage for the remaining local analytics hosts that block analytics on preview deployments: `0.0.0.0` and `::1`.
+
+✨ **Result:** The improvement in test coverage
+The `src/app/analytics.ts` file now has 100% test coverage for all of the hardcoded non-production hosts within `LOCAL_ANALYTICS_HOSTS`.

--- a/src/app/analytics.test.ts
+++ b/src/app/analytics.test.ts
@@ -9,6 +9,8 @@ describe("shouldEnableAnalytics", () => {
 	it("disables analytics for local preview hosts", () => {
 		expect(shouldEnableAnalytics({ hostname: "localhost", isProd: true })).toBe(false);
 		expect(shouldEnableAnalytics({ hostname: "127.0.0.1", isProd: true })).toBe(false);
+		expect(shouldEnableAnalytics({ hostname: "0.0.0.0", isProd: true })).toBe(false);
+		expect(shouldEnableAnalytics({ hostname: "::1", isProd: true })).toBe(false);
 	});
 
 	it("enables analytics for production hosts", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `shouldEnableAnalytics` function in `src/app/analytics.ts` contained a few missing edge cases for testing. The existing test only covered `localhost` and `127.0.0.1`.

📊 **Coverage:** What scenarios are now tested
Added coverage for the remaining local analytics hosts that block analytics on preview deployments: `0.0.0.0` and `::1`.

✨ **Result:** The improvement in test coverage
The `src/app/analytics.ts` file now has 100% test coverage for all of the hardcoded non-production hosts within `LOCAL_ANALYTICS_HOSTS`.

---
*PR created automatically by Jules for task [5664575667858235627](https://jules.google.com/task/5664575667858235627) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Extend shouldEnableAnalytics tests to cover additional local hosts 0.0.0.0 and ::1.