### PR TITLE
refactor: Extract completion logic and UI from TournamentFlow

### DIFF
--- a/src/features/tournament/components/TournamentFlowComplete.tsx
+++ b/src/features/tournament/components/TournamentFlowComplete.tsx
@@ -1,0 +1,54 @@
+import { motion } from "framer-motion";
+import { Trophy } from "@/shared/lib/icons";
+
+interface TournamentFlowCompleteProps {
+	onStartNewTournament: () => void;
+}
+
+export function TournamentFlowComplete({ onStartNewTournament }: TournamentFlowCompleteProps) {
+	return (
+		<motion.div
+			key="complete"
+			initial={{ opacity: 0, scale: 0.95 }}
+			animate={{ opacity: 1, scale: 1 }}
+			exit={{ opacity: 0, scale: 0.95 }}
+			className="flex w-full justify-center py-6 sm:py-10"
+		>
+			<div className="w-full max-w-2xl px-4 text-center sm:px-6">
+				<h2 className="mb-4 bg-gradient-to-r from-primary to-accent bg-clip-text text-2xl font-bold uppercase tracking-tighter text-transparent sm:mb-6 sm:text-3xl md:text-4xl">
+					A victor emerges from the eternal tournament
+				</h2>
+				<div className="mb-6 flex justify-center sm:mb-8">
+					<div className="rounded-full border border-primary/20 bg-primary/10 p-4 sm:p-6">
+						<Trophy className="size-12 text-primary sm:size-14" />
+					</div>
+				</div>
+				<p className="mb-8 text-base text-muted-foreground sm:mb-10 sm:text-lg">
+					Your personal rankings have been updated. Head over to the{" "}
+					<strong className="text-primary">Analyze</strong> section to see the full breakdown and
+					compare results!
+				</p>
+				<div className="flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
+					<button
+						type="button"
+						onClick={() =>
+							document
+								.getElementById("analysis")
+								?.scrollIntoView({ behavior: "smooth", block: "start" })
+						}
+						className="w-full rounded-lg bg-primary px-6 py-3 font-semibold transition-colors hover:bg-primary/90 sm:w-auto"
+					>
+						Analyze Results
+					</button>
+					<button
+						type="button"
+						onClick={onStartNewTournament}
+						className="w-full rounded-lg bg-secondary px-6 py-3 font-semibold transition-colors hover:bg-secondary/80 sm:w-auto"
+					>
+						Start New Tournament
+					</button>
+				</div>
+			</div>
+		</motion.div>
+	);
+}

--- a/src/features/tournament/hooks/index.ts
+++ b/src/features/tournament/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useAudioManager } from "./useHelpers";
 export { useNameSuggestion } from "./useNameSuggestion";
 export { useTournamentHandlers } from "./useTournamentHandlers";
+export { useSaveTournamentRatings } from "./useSaveTournamentRatings";

--- a/src/features/tournament/hooks/useSaveTournamentRatings.ts
+++ b/src/features/tournament/hooks/useSaveTournamentRatings.ts
@@ -1,0 +1,84 @@
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { ratingsAPI } from "@/shared/services/supabase/ratingService";
+import type { VoteRecord } from "@/store/slices/createTournamentSlice";
+
+interface UseSaveTournamentRatingsProps {
+	isComplete: boolean;
+	ratings: Record<string, number | { rating: number; wins: number; losses: number }>;
+	userName: string;
+	voteHistory: VoteRecord[];
+}
+
+export function useSaveTournamentRatings({
+	isComplete,
+	ratings,
+	userName,
+	voteHistory,
+}: UseSaveTournamentRatingsProps) {
+	const saveRatingsMutation = useMutation({
+		mutationFn: ({
+			userId,
+			ratings,
+		}: {
+			userId: string;
+			ratings: Record<string, { rating: number; wins: number; losses: number }>;
+		}) => ratingsAPI.saveRatings(userId, ratings),
+	});
+
+	const mutateAsyncRef = useRef(saveRatingsMutation.mutateAsync);
+	mutateAsyncRef.current = saveRatingsMutation.mutateAsync;
+
+	useEffect(() => {
+		if (isComplete && Object.keys(ratings).length > 0) {
+			const userId = userName || "anonymous";
+
+			// Compute per-name wins and losses from the vote history.
+			// For 1v1, winnerId/loserId are direct name IDs.
+			// For 2v2, winnerMemberIds/loserMemberIds expand team votes to individual names.
+			const winsByName: Record<string, number> = {};
+			const lossesByName: Record<string, number> = {};
+
+			for (const vote of voteHistory) {
+				const winnerIds: string[] = Array.isArray((vote as Record<string, unknown>).winnerMemberIds)
+					? ((vote as Record<string, unknown>).winnerMemberIds as string[])
+					: [String(vote.winnerId)];
+				const loserIds: string[] = Array.isArray((vote as Record<string, unknown>).loserMemberIds)
+					? ((vote as Record<string, unknown>).loserMemberIds as string[])
+					: [String(vote.loserId)];
+
+				for (const id of winnerIds) {
+					winsByName[id] = (winsByName[id] ?? 0) + 1;
+				}
+				for (const id of loserIds) {
+					lossesByName[id] = (lossesByName[id] ?? 0) + 1;
+				}
+			}
+
+			const ratingsWithStats = Object.entries(ratings).reduce(
+				(acc, [nameId, ratingData]) => {
+					const rating = typeof ratingData === "number" ? ratingData : ratingData.rating;
+					acc[nameId] = {
+						rating,
+						wins: winsByName[nameId] ?? 0,
+						losses: lossesByName[nameId] ?? 0,
+					};
+					return acc;
+				},
+				{} as Record<string, { rating: number; wins: number; losses: number }>,
+			);
+
+			mutateAsyncRef
+				.current({ userId, ratings: ratingsWithStats })
+				.then((result) => {
+					if (result?.success) {
+						console.log(`Successfully saved ${result.count} ratings to database`);
+					}
+				})
+				.catch((_error) => {
+					// Error is already logged by ratingsAPI with context
+					console.warn("Tournament ratings save failed — ratings were not persisted");
+				});
+		}
+	}, [isComplete, ratings, userName, voteHistory]);
+}

--- a/src/features/tournament/modes/TournamentFlow.test.tsx
+++ b/src/features/tournament/modes/TournamentFlow.test.tsx
@@ -13,6 +13,7 @@ const mockStore = {
 		isComplete: false,
 		names: null as null | string[],
 		ratings: {} as Record<string, number>,
+		voteHistory: [],
 	},
 	tournamentActions: {},
 };
@@ -25,6 +26,7 @@ vi.mock("../hooks", () => ({
 	useTournamentHandlers: () => ({
 		handleStartNewTournament: mockHandleStartNewTournament,
 	}),
+	useSaveTournamentRatings: vi.fn(),
 }));
 
 vi.mock("../components/NameSelector", () => ({

--- a/src/features/tournament/modes/TournamentFlow.tsx
+++ b/src/features/tournament/modes/TournamentFlow.tsx
@@ -1,147 +1,40 @@
-import { useMutation } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useRef } from "react";
-import { Trophy } from "@/shared/lib/icons";
-import { ratingsAPI } from "@/shared/services/supabase/ratingService";
 import useAppStore from "@/store/appStore";
 import { NameSelector } from "../components/NameSelector";
-import { useTournamentHandlers } from "../hooks";
+import { TournamentFlowComplete } from "../components/TournamentFlowComplete";
+import { useSaveTournamentRatings, useTournamentHandlers } from "../hooks";
 
 export default function TournamentFlow() {
-        const { user, tournament, tournamentActions } = useAppStore();
-        const { handleStartNewTournament } = useTournamentHandlers({
-                userName: user.name,
-                tournamentActions,
-        });
-        const saveRatingsMutation = useMutation({
-                mutationFn: ({
-                        userId,
-                        ratings,
-                }: {
-                        userId: string;
-                        ratings: Record<string, { rating: number; wins: number; losses: number }>;
-                }) => ratingsAPI.saveRatings(userId, ratings),
-        });
+	const { user, tournament, tournamentActions } = useAppStore();
+	const { handleStartNewTournament } = useTournamentHandlers({
+		userName: user.name,
+		tournamentActions,
+	});
 
-        const mutateAsyncRef = useRef(saveRatingsMutation.mutateAsync);
-        mutateAsyncRef.current = saveRatingsMutation.mutateAsync;
+	useSaveTournamentRatings({
+		isComplete: tournament.isComplete,
+		ratings: tournament.ratings,
+		userName: user.name,
+		voteHistory: tournament.voteHistory,
+	});
 
-        useEffect(() => {
-                if (tournament.isComplete && Object.keys(tournament.ratings).length > 0) {
-                        const userId = user.name || "anonymous";
-
-                        // Compute per-name wins and losses from the vote history.
-                        // For 1v1, winnerId/loserId are direct name IDs.
-                        // For 2v2, winnerMemberIds/loserMemberIds expand team votes to individual names.
-                        const winsByName: Record<string, number> = {};
-                        const lossesByName: Record<string, number> = {};
-
-                        for (const vote of tournament.voteHistory) {
-                                const winnerIds: string[] =
-                                        Array.isArray((vote as Record<string, unknown>).winnerMemberIds)
-                                                ? ((vote as Record<string, unknown>).winnerMemberIds as string[])
-                                                : [String(vote.winnerId)];
-                                const loserIds: string[] =
-                                        Array.isArray((vote as Record<string, unknown>).loserMemberIds)
-                                                ? ((vote as Record<string, unknown>).loserMemberIds as string[])
-                                                : [String(vote.loserId)];
-
-                                for (const id of winnerIds) {
-                                        winsByName[id] = (winsByName[id] ?? 0) + 1;
-                                }
-                                for (const id of loserIds) {
-                                        lossesByName[id] = (lossesByName[id] ?? 0) + 1;
-                                }
-                        }
-
-                        const ratingsWithStats = Object.entries(tournament.ratings).reduce(
-                                (acc, [nameId, ratingData]) => {
-                                        const rating = typeof ratingData === "number" ? ratingData : ratingData.rating;
-                                        acc[nameId] = {
-                                                rating,
-                                                wins: winsByName[nameId] ?? 0,
-                                                losses: lossesByName[nameId] ?? 0,
-                                        };
-                                        return acc;
-                                },
-                                {} as Record<string, { rating: number; wins: number; losses: number }>,
-                        );
-
-                        mutateAsyncRef.current({ userId, ratings: ratingsWithStats })
-                                .then((result) => {
-                                        if (result?.success) {
-                                                console.log(`Successfully saved ${result.count} ratings to database`);
-                                        }
-                                })
-                                .catch((_error) => {
-                                        // Error is already logged by ratingsAPI with context
-                                        console.warn("Tournament ratings save failed — ratings were not persisted");
-                                });
-                }
-        }, [
-                tournament.isComplete,
-                tournament.ratings,
-                user.name,
-                tournament.voteHistory,
-        ]);
-
-        return (
-                <div className="w-full flex flex-col gap-2">
-                        <AnimatePresence mode="wait">
-                                {tournament.isComplete && tournament.names !== null ? (
-                                        <motion.div
-                                                key="complete"
-                                                initial={{ opacity: 0, scale: 0.95 }}
-                                                animate={{ opacity: 1, scale: 1 }}
-                                                exit={{ opacity: 0, scale: 0.95 }}
-                                                className="w-full flex justify-center py-6 sm:py-10"
-                                        >
-                                                <div className="w-full max-w-2xl text-center px-4 sm:px-6">
-                                                        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent uppercase tracking-tighter">
-                                                                A victor emerges from the eternal tournament
-                                                        </h2>
-                                                        <div className="flex justify-center mb-6 sm:mb-8">
-                                                                <div className="p-4 sm:p-6 bg-primary/10 rounded-full border border-primary/20">
-                                                                        <Trophy className="size-12 sm:size-14 text-primary" />
-                                                                </div>
-                                                        </div>
-                                                        <p className="text-base sm:text-lg text-muted-foreground mb-8 sm:mb-10">
-                                                                Your personal rankings have been updated. Head over to the{" "}
-                                                                <strong className="text-primary">Analyze</strong> section to see the full breakdown
-                                                                and compare results!
-                                                        </p>
-                                                        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-                                                                <button
-                                                                        onClick={() =>
-                                                                                document
-                                                                                        .getElementById("analysis")
-                                                                                        ?.scrollIntoView({ behavior: "smooth", block: "start" })
-                                                                        }
-                                                                        className="w-full sm:w-auto px-6 py-3 bg-primary hover:bg-primary/90 rounded-lg font-semibold transition-colors"
-                                                                >
-                                                                        Analyze Results
-                                                                </button>
-                                                                <button
-                                                                        onClick={handleStartNewTournament}
-                                                                        className="w-full sm:w-auto px-6 py-3 bg-secondary hover:bg-secondary/80 rounded-lg font-semibold transition-colors"
-                                                                >
-                                                                        Start New Tournament
-                                                                </button>
-                                                        </div>
-                                                </div>
-                                        </motion.div>
-                                ) : (
-                                        <motion.div
-                                                key="setup"
-                                                initial={{ opacity: 0 }}
-                                                animate={{ opacity: 1 }}
-                                                exit={{ opacity: 0 }}
-                                                className="w-full py-0"
-                                        >
-                                                <NameSelector />
-                                        </motion.div>
-                                )}
-                        </AnimatePresence>
-                </div>
-        );
+	return (
+		<div className="flex w-full flex-col gap-2">
+			<AnimatePresence mode="wait">
+				{tournament.isComplete && tournament.names !== null ? (
+					<TournamentFlowComplete onStartNewTournament={handleStartNewTournament} />
+				) : (
+					<motion.div
+						key="setup"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						className="w-full py-0"
+					>
+						<NameSelector />
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	);
 }


### PR DESCRIPTION
🎯 **What:** Extracted the completion UI into `TournamentFlowComplete.tsx` and the side-effect logic for computing and saving tournament ratings into a new `useSaveTournamentRatings` hook.
💡 **Why:** This directly addresses the code health issue of "Overly long function 'TournamentFlow'", significantly improving readability, testability, and separation of concerns by pulling out independent logic into their own dedicated files. 
✅ **Verification:** Ran `pnpm dlx @biomejs/biome check --write` to ensure proper formatting, and executed the test suite with `pnpm test`, confirming the changes don't break existing behaviors. Also mocked the new hook in the original component test.
✨ **Result:** The `TournamentFlow` component is now slim and focused purely on rendering the conditional flow wrapper, making it much more maintainable.

---
*PR created automatically by Jules for task [13283861169381155179](https://jules.google.com/task/13283861169381155179) started by @guitarbeat*