### PR TITLE
🔒 fix(auth): remove hardcoded password in auth adapter

### DIFF
--- a/src/shared/services/supabase/authAdapter.ts
+++ b/src/shared/services/supabase/authAdapter.ts
@@ -1,9 +1,4 @@
-import type {
-	AuthAdapter,
-	AuthUser,
-	LoginCredentials,
-} from "@/app/providers/Providers";
-import { STORAGE_KEYS } from "@/shared/lib/constants";
+import type { AuthAdapter, AuthUser, LoginCredentials } from "@/app/providers/Providers";
 import { isStorageAvailable } from "@/shared/lib/storage";
 import {
 	clearStoredUserSnapshot,
@@ -106,17 +101,22 @@ export const supabaseAuthAdapter: AuthAdapter = {
 				writeStoredUserSnapshot({
 					...storedUser,
 					name: trimmedName,
-					isAdmin:
-						storedUser?.name === trimmedName ? storedUser.isAdmin : false,
+					isAdmin: storedUser?.name === trimmedName ? storedUser.isAdmin : false,
 				});
 				return true;
 			}
 
 			// Sign in with Supabase
+			const demoPassword = import.meta.env.VITE_SUPABASE_DEMO_PASSWORD;
+			if (!demoPassword) {
+				console.error("Missing VITE_SUPABASE_DEMO_PASSWORD environment variable.");
+				return false;
+			}
+
 			const sanitizedEmail = `${sanitizeNameForEmail(trimmedName)}@demo.local`;
 			const { data, error } = await client.auth.signInWithPassword({
 				email: sanitizedEmail,
-				password: "demo-password", // Demo password
+				password: demoPassword,
 			});
 
 			if (error) {
@@ -153,9 +153,7 @@ export const supabaseAuthAdapter: AuthAdapter = {
 	 * Register new user with Supabase Auth
 	 */
 	async register(): Promise<void> {
-		throw new Error(
-			"Registration not implemented. Please use Supabase Auth directly.",
-		);
+		throw new Error("Registration not implemented. Please use Supabase Auth directly.");
 	},
 
 	/**


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded `"demo-password"` in the name-based login flow with the `VITE_SUPABASE_DEMO_PASSWORD` environment variable.

⚠️ **Risk:** Hardcoded passwords in the auth adapter pose a significant security risk, as anyone with access to the source code or the client bundle could potentially use it to authenticate as any user via the demo local domain.

🛡️ **Solution:** The authentication flow now strictly relies on the `VITE_SUPABASE_DEMO_PASSWORD` environment variable. If the variable is missing, the login aborts safely and logs an error to the console, preventing unauthorized access while maintaining the intended functionality of the demo mode.

---
*PR created automatically by Jules for task [10745502927462067000](https://jules.google.com/task/10745502927462067000) started by @guitarbeat*