### PR TITLE
test(stats): add comprehensive tests for leaderboardAPI

### DIFF
--- a/src/shared/services/supabase/statsService.test.ts
+++ b/src/shared/services/supabase/statsService.test.ts
@@ -1,26 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { leaderboardAPI } from "./statsService";
+import { computeRatingStats, getPercentileRank } from "@/shared/lib/ratingStats";
 import { withSupabase } from "./runtime";
+import { leaderboardAPI } from "./statsService";
 
 vi.mock("./runtime", () => ({
 	withSupabase: vi.fn(),
 	resolveSupabaseClient: vi.fn(),
 }));
 
+vi.mock("@/shared/lib/ratingStats", () => ({
+	computeRatingStats: vi.fn(),
+	getPercentileRank: vi.fn(),
+}));
+
 describe("leaderboardAPI", () => {
 	const mockedWithSupabase = vi.mocked(withSupabase);
+	const mockedComputeRatingStats = vi.mocked(computeRatingStats);
+	const mockedGetPercentileRank = vi.mocked(getPercentileRank);
+
+	let mockRpc: any;
+	let mockClient: any;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockRpc = vi.fn();
+		mockClient = {
+			rpc: mockRpc,
+		};
+
+		// By default, execute the callback with our mock client
+		mockedWithSupabase.mockImplementation(async (callback, fallback) => {
+			try {
+				return await callback(mockClient);
+			} catch (_e) {
+				return fallback;
+			}
+		});
 	});
 
-	it("calls get_leaderboard_stats RPC and maps rows", async () => {
-		const mockRows = [
+	it("calls get_leaderboard_stats RPC with correct limit and maps rows", async () => {
+		const mockData = [
 			{
 				name_id: "id-1",
 				name: "Cat 1",
 				avg_rating: 1600,
 				wins: 5,
+				losses: 2,
 				total_ratings: 10,
 				created_at: "2023-01-01",
 			},
@@ -29,37 +54,124 @@ describe("leaderboardAPI", () => {
 				name: "Cat 2",
 				avg_rating: 1500,
 				wins: 0,
+				losses: 0,
 				total_ratings: 0,
 				date_submitted: "2023-01-02",
 			},
 		];
 
-		mockedWithSupabase.mockResolvedValueOnce(
-			mockRows.map((row) => ({
-				name_id: String(row.name_id ?? ""),
-				name: String(row.name ?? ""),
-				avg_rating: Number(row.avg_rating ?? 0),
-				wins: Number(row.wins ?? 0),
-				total_ratings: Number(row.total_ratings ?? 0),
-				created_at: row.created_at ?? null,
-				date_submitted: row.date_submitted ?? null,
-			})),
-		);
+		mockRpc.mockResolvedValueOnce({ data: mockData, error: null });
+
+		mockedComputeRatingStats.mockReturnValue({
+			mean: 1550,
+			stdDev: 50,
+			median: 1550,
+			min: 1500,
+			max: 1600,
+			percentile90: 1590,
+			percentile99: 1599,
+		});
+
+		mockedGetPercentileRank.mockImplementation((rating) => {
+			if (rating === 1600) {
+				return 99;
+			}
+			if (rating === 1500) {
+				return 10;
+			}
+			return 50;
+		});
 
 		const result = await leaderboardAPI.getLeaderboard(25);
 
-		expect(mockedWithSupabase).toHaveBeenCalled();
+		expect(mockRpc).toHaveBeenCalledWith("get_leaderboard_stats", {
+			limit_count: 25,
+		});
+
+		expect(mockedComputeRatingStats).toHaveBeenCalledWith([1600, 1500]);
+		expect(mockedGetPercentileRank).toHaveBeenCalledTimes(2);
+
 		expect(result).toHaveLength(2);
-		expect(result[0]?.name).toBe("Cat 1");
-		expect(result[0]?.avg_rating).toBe(1600);
-		expect(result[1]?.name).toBe("Cat 2");
+
+		// Check first mapped item
+		expect(result[0]).toEqual(
+			expect.objectContaining({
+				name_id: "id-1",
+				name: "Cat 1",
+				avg_rating: 1600,
+				wins: 5,
+				losses: 2,
+				total_ratings: 10,
+				percentile_rank: 99,
+				confidence: 10 / 15,
+				created_at: "2023-01-01",
+				date_submitted: null,
+			}),
+		);
+
+		// Check second mapped item
+		expect(result[1]).toEqual(
+			expect.objectContaining({
+				name_id: "id-2",
+				name: "Cat 2",
+				avg_rating: 1500,
+				wins: 0,
+				losses: 0,
+				total_ratings: 0,
+				percentile_rank: 10,
+				confidence: 0,
+				created_at: null,
+				date_submitted: "2023-01-02",
+			}),
+		);
 	});
 
-	it("returns empty array when withSupabase fallback is returned", async () => {
-		mockedWithSupabase.mockResolvedValueOnce([]);
+	it("uses default limit 50 when limit is null", async () => {
+		mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+		await leaderboardAPI.getLeaderboard(null);
+
+		expect(mockRpc).toHaveBeenCalledWith("get_leaderboard_stats", {
+			limit_count: 50,
+		});
+	});
+
+	it("returns empty array when RPC returns an error", async () => {
+		const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+			/* suppress warning */
+		});
+
+		mockRpc.mockResolvedValueOnce({ data: null, error: { message: "Database error" } });
 
 		const result = await leaderboardAPI.getLeaderboard(50);
 
 		expect(result).toEqual([]);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			"[statsService] get_leaderboard_stats failed:",
+			"Database error",
+		);
+
+		consoleWarnSpy.mockRestore();
+	});
+
+	it("handles missing stats gracefully (confidence = 0)", async () => {
+		const mockData = [
+			{
+				name_id: "id-1",
+				name: "Cat 1",
+				avg_rating: 1600,
+				total_ratings: 20, // would be > 15, so confidence would normally be 1
+			},
+		];
+
+		mockRpc.mockResolvedValueOnce({ data: mockData, error: null });
+
+		// computeRatingStats returns null if there's an error or empty input
+		mockedComputeRatingStats.mockReturnValue(null);
+
+		const result = await leaderboardAPI.getLeaderboard(10);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.confidence).toBe(0);
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `leaderboardAPI` within `src/shared/services/supabase/statsService.ts` has been addressed. The previous tests mocked `withSupabase` such that the implementation logic of the API method was bypassed entirely.

📊 **Coverage:**
* Tested correct parameter mapping (`limit_count`) to the `get_leaderboard_stats` RPC.
* Handled the missing default value scenario for `limit`.
* Verified mapping logic by mocking `@/shared/lib/ratingStats`, checking correctness for `percentile_rank` and `confidence` calculation.
* Added an error path test ensuring it returns an empty array and logs warnings.
* Added an edge case test ensuring proper `confidence` default when stats generation fails.

✨ **Result:** Improved test coverage and reliability for `leaderboardAPI`. The logic that maps Supabase responses to the application's leaderboard formats is now verified by the test suite, preventing regressions.

---
*PR created automatically by Jules for task [11400787408920581598](https://jules.google.com/task/11400787408920581598) started by @guitarbeat*