### PR TITLE
🧹 Hide production console warnings in TournamentRealtimeService

### DIFF
--- a/src/features/tournament/hooks/useTournamentRealtime.ts
+++ b/src/features/tournament/hooks/useTournamentRealtime.ts
@@ -1,6 +1,7 @@
 import type { RealtimeChannel } from "@supabase/supabase-js";
 import { useCallback, useEffect, useRef } from "react";
 import { resolveSupabaseClient } from "@/shared/services/supabase/runtime";
+import { IS_DEV } from "@/store/appStore.shared";
 
 export interface TournamentUpdate {
 	tournamentId: string;
@@ -36,10 +37,7 @@ class TournamentRealtimeService {
 	private ratingChangeCallbacks: Array<(payload: unknown) => void> = [];
 
 	async connect(): Promise<void> {
-		if (
-			this.connectionState === "connected" ||
-			this.connectionState === "connecting"
-		) {
+		if (this.connectionState === "connected" || this.connectionState === "connecting") {
 			return;
 		}
 		this.connectionState = "connecting";
@@ -70,7 +68,9 @@ class TournamentRealtimeService {
 					}
 				});
 		} catch (error) {
-			console.warn("[TournamentRealtimeService] Failed to connect:", error);
+			if (IS_DEV) {
+				console.warn("[TournamentRealtimeService] Failed to connect:", error);
+			}
 			this.connectionState = "error";
 		}
 	}
@@ -145,15 +145,11 @@ class TournamentRealtimeService {
 
 		this.ratingChangeCallbacks.push(handler);
 		return () => {
-			this.ratingChangeCallbacks = this.ratingChangeCallbacks.filter(
-				(cb) => cb !== handler,
-			);
+			this.ratingChangeCallbacks = this.ratingChangeCallbacks.filter((cb) => cb !== handler);
 		};
 	}
 
-	subscribeToUserActivity(
-		callback: (activity: UserActivity) => void,
-	): () => void {
+	subscribeToUserActivity(callback: (activity: UserActivity) => void): () => void {
 		let presenceChannel: RealtimeChannel | null = null;
 		let cancelled = false;
 
@@ -168,8 +164,7 @@ class TournamentRealtimeService {
 					for (const presence of newPresences) {
 						callback({
 							userId: String(
-								(presence as Record<string, unknown>).user_id ??
-									presence.presence_ref,
+								(presence as Record<string, unknown>).user_id ?? presence.presence_ref,
 							),
 							action: "joined",
 							timestamp: Date.now(),
@@ -180,8 +175,7 @@ class TournamentRealtimeService {
 					for (const presence of leftPresences) {
 						callback({
 							userId: String(
-								(presence as Record<string, unknown>).user_id ??
-									presence.presence_ref,
+								(presence as Record<string, unknown>).user_id ?? presence.presence_ref,
 							),
 							action: "left",
 							timestamp: Date.now(),
@@ -216,9 +210,7 @@ interface UseTournamentRealtimeOptions {
 	autoConnect?: boolean;
 }
 
-export function useTournamentRealtime(
-	options: UseTournamentRealtimeOptions = {},
-) {
+export function useTournamentRealtime(options: UseTournamentRealtimeOptions = {}) {
 	const serviceRef = useRef<TournamentRealtimeService | null>(null);
 
 	useEffect(() => {
@@ -226,7 +218,13 @@ export function useTournamentRealtime(
 			serviceRef.current = getTournamentRealtimeService();
 
 			if (options.autoConnect) {
-				serviceRef.current.connect().catch(console.error);
+				serviceRef.current.connect().catch((error) => {
+					if (IS_DEV) {
+						console.error("[TournamentRealtimeService] Connect error:", error);
+					} else {
+						// Error handled silently in production
+					}
+				});
 			}
 		}
 
@@ -243,19 +241,13 @@ export function useTournamentRealtime(
 		[],
 	);
 
-	const subscribeToMatches = useCallback(
-		(callback: (result: MatchResult) => void) => {
-			return serviceRef.current?.subscribeToMatches(callback);
-		},
-		[],
-	);
+	const subscribeToMatches = useCallback((callback: (result: MatchResult) => void) => {
+		return serviceRef.current?.subscribeToMatches(callback);
+	}, []);
 
-	const subscribeToUserActivity = useCallback(
-		(callback: (activity: UserActivity) => void) => {
-			return serviceRef.current?.subscribeToUserActivity(callback);
-		},
-		[],
-	);
+	const subscribeToUserActivity = useCallback((callback: (activity: UserActivity) => void) => {
+		return serviceRef.current?.subscribeToUserActivity(callback);
+	}, []);
 
 	const cleanup = useCallback(() => {
 		serviceRef.current?.cleanup();


### PR DESCRIPTION
🎯 **What:** Wrapped `console.warn` and `console.error` calls in `IS_DEV` environment checks inside `useTournamentRealtime.ts`.

💡 **Why:** The codebase convention implies logging non-fatal connectivity issues silently in production. Conditionally exposing these logs reduces clutter in production environments and avoids confusing users who monitor browser dev tools, making the codebase healthier.

✅ **Verification:** Verified by checking type safety via `pnpm run check`, executing all standard unit tests `pnpm test`, and running code reviews and Biome checks to conform to code health standards like `noEmptyBlockStatements`.

✨ **Result:** A cleaner implementation with conditional DEV-only error output for real-time tournament connections without disrupting underlying logic.

---
*PR created automatically by Jules for task [6906188619989601127](https://jules.google.com/task/6906188619989601127) started by @guitarbeat*