### PR TITLE
🧹 [Code Health] Remove production console.error usage in ErrorBoundary

### DIFF
--- a/src/shared/components/layout/Feedback/ErrorBoundary.tsx
+++ b/src/shared/components/layout/Feedback/ErrorBoundary.tsx
@@ -158,8 +158,8 @@ ${error?.stack || "No stack trace available"}
                         await navigator.clipboard.writeText(errorDetails);
                         setCopySuccess(true);
                         setTimeout(() => setCopySuccess(false), 2000);
-                } catch (err) {
-                        console.error("Failed to copy error details:", err);
+                } catch {
+                        // Silently ignore clipboard failures in production to avoid console spam
                 }
         };
 


### PR DESCRIPTION
🎯 **What:** Removed the `console.error` call in `ErrorBoundary.tsx` that triggers when copying error details to the clipboard fails, and replaced it with a comment.
💡 **Why:** Silently swallows the non-critical clipboard failure to prevent console spam in production.
✅ **Verification:** Verified by checking out the main branch, making the isolated change with a simple python regex script, confirming the diff size was tiny (2 lines removed, 2 lines added), and avoiding running the whole-file `biome format` command to keep the diff clean for reviewers.
✨ **Result:** Improved codebase cleanliness and reduced unhelpful log noise.

---
*PR created automatically by Jules for task [3585552354847663433](https://jules.google.com/task/3585552354847663433) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Stop logging clipboard copy failures in the error boundary by swallowing non-critical errors instead of calling console.error.