### PR TITLE
🧹 [code health improvement] Remove console.error from useAsyncData

### DIFF
--- a/src/features/analytics/hooks/useDashboardData.ts
+++ b/src/features/analytics/hooks/useDashboardData.ts
@@ -1,99 +1,122 @@
 import { useCallback, useEffect, useState } from "react";
-import {
-        type LeaderboardItem,
-        leaderboardAPI,
-        type SiteStats,
-        statsAPI,
-        type UserStats,
-        type EngagementMetrics,
-} from "@/shared/services/supabase/statsService";
 import { fetchHiddenNames, unhideName } from "@/features/names/api";
 import { useAsyncData } from "@/shared/hooks/useAsyncData";
+import {
+	type EngagementMetrics,
+	type LeaderboardItem,
+	leaderboardAPI,
+	type SiteStats,
+	statsAPI,
+	type UserStats,
+} from "@/shared/services/supabase/statsService";
 
 export type DashboardTimeframe = "day" | "week" | "month";
 
 export interface HiddenNameListItem {
-        id: string | number;
-        name: string;
+	id: string | number;
+	name: string;
 }
 
 interface UseDashboardDataParams {
-        isAdmin?: boolean;
-        userName?: string;
+	isAdmin?: boolean;
+	userName?: string;
 }
 
 export function useDashboardData({ isAdmin = false, userName = "" }: UseDashboardDataParams) {
-        const normalizedUserName = userName.trim();
+	const normalizedUserName = userName.trim();
 
-        const [timeframe, setTimeframe] = useState<DashboardTimeframe>("week");
-        const [showHiddenNames, setShowHiddenNames] = useState(false);
-        const [hiddenNames, setHiddenNames] = useState<HiddenNameListItem[]>([]);
+	const [timeframe, setTimeframe] = useState<DashboardTimeframe>("week");
+	const [showHiddenNames, setShowHiddenNames] = useState(false);
+	const [hiddenNames, setHiddenNames] = useState<HiddenNameListItem[]>([]);
 
-        const { data: leaderboard, isLoading: isLoadingLeaderboard } = useAsyncData<LeaderboardItem[]>(
-                () => leaderboardAPI.getLeaderboard(10),
-                [],
-        );
+	const {
+		data: leaderboard,
+		isLoading: isLoadingLeaderboard,
+		error: errorLeaderboard,
+	} = useAsyncData<LeaderboardItem[]>(() => leaderboardAPI.getLeaderboard(10), []);
 
-        const { data: engagementMetrics, isLoading: isLoadingEngagement, refresh: refreshEngagementMetrics } =
-                useAsyncData<EngagementMetrics | null>(
-                        () => statsAPI.getEngagementMetrics(timeframe as "day" | "week" | "month" | "year"),
-                        null,
-                        { deps: [timeframe] },
-                );
+	const {
+		data: engagementMetrics,
+		isLoading: isLoadingEngagement,
+		error: errorEngagement,
+		refresh: refreshEngagementMetrics,
+	} = useAsyncData<EngagementMetrics | null>(
+		() => statsAPI.getEngagementMetrics(timeframe as "day" | "week" | "month" | "year"),
+		null,
+		{ deps: [timeframe] },
+	);
 
-        const { data: siteStats } = useAsyncData<SiteStats | null>(
-                () => statsAPI.getSiteStats(),
-                null,
-        );
+	const { data: siteStats, error: errorSiteStats } = useAsyncData<SiteStats | null>(
+		() => statsAPI.getSiteStats(),
+		null,
+	);
 
-        const { data: userStats } = useAsyncData<UserStats | null>(
-                () => (normalizedUserName ? statsAPI.getUserStats(normalizedUserName) : Promise.resolve(null)),
-                null,
-                { deps: [normalizedUserName] },
-        );
+	const { data: userStats, error: errorUserStats } = useAsyncData<UserStats | null>(
+		() => (normalizedUserName ? statsAPI.getUserStats(normalizedUserName) : Promise.resolve(null)),
+		null,
+		{ deps: [normalizedUserName] },
+	);
 
-        useEffect(() => {
-                if (!isAdmin || !showHiddenNames) return;
+	useEffect(() => {
+		if (!isAdmin || !showHiddenNames) {
+			return;
+		}
 
-                let isActive = true;
-                fetchHiddenNames()
-                        .then((result) => { if (isActive) setHiddenNames(result.names); })
-                        .catch((error) => { console.error("Failed to fetch hidden names:", error); });
+		let isActive = true;
+		fetchHiddenNames()
+			.then((result) => {
+				if (isActive) {
+					setHiddenNames(result.names);
+				}
+			})
+			.catch((error) => {
+				console.error("Failed to fetch hidden names:", error);
+			});
 
-                return () => { isActive = false; };
-        }, [isAdmin, showHiddenNames]);
+		return () => {
+			isActive = false;
+		};
+	}, [isAdmin, showHiddenNames]);
 
-        const toggleHiddenNames = useCallback(() => {
-                setShowHiddenNames((current) => !current);
-        }, []);
+	const toggleHiddenNames = useCallback(() => {
+		setShowHiddenNames((current) => !current);
+	}, []);
 
-        const handleUnhideName = useCallback(
-                async (nameId: string | number) => {
-                        if (!normalizedUserName) return;
-                        try {
-                                const result = await unhideName(normalizedUserName, String(nameId));
-                                if (!result.success) throw new Error(result.error || "Failed to unhide name");
-                                setHiddenNames((current) => current.filter((name) => name.id !== nameId));
-                        } catch (error) {
-                                console.error("Failed to unhide name:", error);
-                        }
-                },
-                [normalizedUserName],
-        );
+	const handleUnhideName = useCallback(
+		async (nameId: string | number) => {
+			if (!normalizedUserName) {
+				return;
+			}
+			try {
+				const result = await unhideName(normalizedUserName, String(nameId));
+				if (!result.success) {
+					throw new Error(result.error || "Failed to unhide name");
+				}
+				setHiddenNames((current) => current.filter((name) => name.id !== nameId));
+			} catch (error) {
+				console.error("Failed to unhide name:", error);
+			}
+		},
+		[normalizedUserName],
+	);
 
-        return {
-                engagementMetrics,
-                handleUnhideName,
-                hiddenNames,
-                isLoadingEngagement,
-                isLoadingLeaderboard,
-                leaderboard,
-                refreshEngagementMetrics,
-                setTimeframe,
-                showHiddenNames,
-                siteStats,
-                timeframe,
-                toggleHiddenNames,
-                userStats,
-        };
+	return {
+		engagementMetrics,
+		errorEngagement,
+		errorLeaderboard,
+		errorSiteStats,
+		errorUserStats,
+		handleUnhideName,
+		hiddenNames,
+		isLoadingEngagement,
+		isLoadingLeaderboard,
+		leaderboard,
+		refreshEngagementMetrics,
+		setTimeframe,
+		showHiddenNames,
+		siteStats,
+		timeframe,
+		toggleHiddenNames,
+		userStats,
+	};
 }

--- a/src/shared/hooks/useAsyncData.test.ts
+++ b/src/shared/hooks/useAsyncData.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useAsyncData } from "./useAsyncData";
+
+// @vitest-environment jsdom
+
+describe("useAsyncData", () => {
+	it("should return initial data and loading state", async () => {
+		const fetcher = vi.fn().mockResolvedValue("data");
+		const { result } = renderHook(() => useAsyncData(fetcher, "initial"));
+
+		expect(result.current.data).toBe("initial");
+		expect(result.current.isLoading).toBe(true);
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(result.current.data).toBe("data");
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.error).toBe(null);
+	});
+
+	it("should handle errors", async () => {
+		const fetcher = vi.fn().mockRejectedValue(new Error("Test error"));
+		const { result } = renderHook(() => useAsyncData(fetcher, "initial"));
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(result.current.data).toBe("initial");
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.error).toBeInstanceOf(Error);
+		expect(result.current.error?.message).toBe("Test error");
+	});
+});

--- a/src/shared/hooks/useAsyncData.ts
+++ b/src/shared/hooks/useAsyncData.ts
@@ -1,58 +1,70 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseAsyncDataOptions {
-        deps?: unknown[];
+	deps?: unknown[];
 }
 
 interface UseAsyncDataResult<T> {
-        data: T;
-        isLoading: boolean;
-        refresh: () => Promise<void>;
+	data: T;
+	isLoading: boolean;
+	error: Error | null;
+	refresh: () => Promise<void>;
 }
 
 export function useAsyncData<T>(
-        fetcher: () => Promise<T>,
-        initialValue: T,
-        options: UseAsyncDataOptions = {},
+	fetcher: () => Promise<T>,
+	initialValue: T,
+	options: UseAsyncDataOptions = {},
 ): UseAsyncDataResult<T> {
-        const { deps = [] } = options;
-        const [data, setData] = useState<T>(initialValue);
-        const [isLoading, setIsLoading] = useState(true);
-        const fetcherRef = useRef(fetcher);
-        fetcherRef.current = fetcher;
+	const { deps = [] } = options;
+	const [data, setData] = useState<T>(initialValue);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<Error | null>(null);
+	const fetcherRef = useRef(fetcher);
+	fetcherRef.current = fetcher;
 
-        const run = useCallback(async () => {
-                setIsLoading(true);
-                try {
-                        const result = await fetcherRef.current();
-                        setData(result);
-                } catch (error) {
-                        console.error("[useAsyncData] Fetch failed:", error);
-                } finally {
-                        setIsLoading(false);
-                }
-        }, []);
+	const run = useCallback(async () => {
+		setIsLoading(true);
+		setError(null);
+		try {
+			const result = await fetcherRef.current();
+			setData(result);
+		} catch (error) {
+			// Errors are typically handled by the consumer
+			setError(error instanceof Error ? error : new Error(String(error)));
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
 
-        useEffect(() => {
-                let isActive = true;
-                setIsLoading(true);
+	useEffect(() => {
+		let isActive = true;
+		setIsLoading(true);
+		setError(null);
 
-                fetcherRef.current()
-                        .then((result) => {
-                                if (isActive) setData(result);
-                        })
-                        .catch((error) => {
-                                console.error("[useAsyncData] Fetch failed:", error);
-                        })
-                        .finally(() => {
-                                if (isActive) setIsLoading(false);
-                        });
+		fetcherRef
+			.current()
+			.then((result) => {
+				if (isActive) {
+					setData(result);
+				}
+			})
+			.catch((error) => {
+				if (isActive) {
+					setError(error instanceof Error ? error : new Error(String(error)));
+				}
+			})
+			.finally(() => {
+				if (isActive) {
+					setIsLoading(false);
+				}
+			});
 
-                return () => {
-                        isActive = false;
-                };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, deps);
+		return () => {
+			isActive = false;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps);
 
-        return { data, isLoading, refresh: run };
+	return { data, isLoading, error, refresh: run };
 }


### PR DESCRIPTION
🎯 **What:** Removed production `console.error` calls from `useAsyncData` and updated it to correctly surface an `error` state.
💡 **Why:** Consumers of the `useAsyncData` hook were not provided an explicit way to handle errors properly as they were just swallowed and logged to the console. Adding an `error` state provides better error handling delegation and improves code health.
✅ **Verification:** Added comprehensive test coverage in `useAsyncData.test.ts`. Verified the change compiles properly using `pnpm run check` and passes the full `pnpm run test` suite.
✨ **Result:** Better error control inversion to callers without cluttering application runtime logs, along with improved typing.

---
*PR created automatically by Jules for task [14314876005723409290](https://jules.google.com/task/14314876005723409290) started by @guitarbeat*