### PR TITLE
feat: integrate gooey text morphing component

### DIFF
--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -6,6 +6,7 @@ import {
         TournamentBracketSection,
 } from "@/app/routes/components/HomeSections";
 import { namesQueryOptions } from "@/features/names/api";
+import { GooeyTextDemo } from "@/components/ui/demo";
 import { useTournamentHandlers } from "@/features/tournament/hooks";
 import { ErrorBoundary, Loading } from "@/shared/components/layout/Feedback";
 import { useMediaQuery } from "@/shared/hooks/useBrowserState";
@@ -124,6 +125,9 @@ export default function HomeRoute() {
                                         </ErrorBoundary>
                                 </Suspense>
                         </div>
+                        <Section variant="card" padding="comfortable" maxWidth="xl">
+                                <GooeyTextDemo />
+                        </Section>
                 </>
         );
 }

--- a/src/components/ui/demo.tsx
+++ b/src/components/ui/demo.tsx
@@ -1,0 +1,27 @@
+import { GooeyText } from "@/components/ui/gooey-text-morphing";
+import { Cat } from "lucide-react";
+
+function GooeyTextDemo() {
+  return (
+    <div className="relative w-full h-[400px] flex items-center justify-center overflow-hidden rounded-xl bg-muted/20">
+      <div className="absolute inset-0 opacity-20">
+        <img
+          src="https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?auto=format&fit=crop&q=80&w=2043&ixlib=rb-4.0.3"
+          alt="Cat background"
+          className="w-full h-full object-cover"
+        />
+      </div>
+      <div className="z-10 flex flex-col items-center gap-8">
+        <Cat className="w-12 h-12 text-primary" />
+        <GooeyText
+          texts={["Design", "Engineering", "Is", "Awesome", "With", "Cats"]}
+          morphTime={1}
+          cooldownTime={0.5}
+          className="font-bold min-h-[100px] w-full"
+        />
+      </div>
+    </div>
+  );
+}
+
+export { GooeyTextDemo };

--- a/src/components/ui/gooey-text-morphing.tsx
+++ b/src/components/ui/gooey-text-morphing.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/shared/lib/utils";
+
+interface GooeyTextProps {
+  texts: string[];
+  morphTime?: number;
+  cooldownTime?: number;
+  className?: string;
+  textClassName?: string;
+}
+
+export function GooeyText({
+  texts,
+  morphTime = 1,
+  cooldownTime = 0.25,
+  className,
+  textClassName
+}: GooeyTextProps) {
+  const text1Ref = React.useRef<HTMLSpanElement>(null);
+  const text2Ref = React.useRef<HTMLSpanElement>(null);
+
+  React.useEffect(() => {
+    let textIndex = texts.length - 1;
+    let time = new Date();
+    let morph = 0;
+    let cooldown = cooldownTime;
+
+    const setMorph = (fraction: number) => {
+      if (text1Ref.current && text2Ref.current) {
+        text2Ref.current.style.filter = `blur(${Math.min(8 / fraction - 8, 100)}px)`;
+        text2Ref.current.style.opacity = `${Math.pow(fraction, 0.4) * 100}%`;
+
+        const invertedFraction = 1 - fraction;
+        text1Ref.current.style.filter = `blur(${Math.min(8 / invertedFraction - 8, 100)}px)`;
+        text1Ref.current.style.opacity = `${Math.pow(invertedFraction, 0.4) * 100}%`;
+      }
+    };
+
+    const doCooldown = () => {
+      morph = 0;
+      if (text1Ref.current && text2Ref.current) {
+        text2Ref.current.style.filter = "";
+        text2Ref.current.style.opacity = "100%";
+        text1Ref.current.style.filter = "";
+        text1Ref.current.style.opacity = "0%";
+      }
+    };
+
+    const doMorph = () => {
+      morph -= cooldown;
+      cooldown = 0;
+      let fraction = morph / morphTime;
+
+      if (fraction > 1) {
+        cooldown = cooldownTime;
+        fraction = 1;
+      }
+
+      setMorph(fraction);
+    };
+
+    function animate() {
+      requestAnimationFrame(animate);
+      const newTime = new Date();
+      const shouldIncrementIndex = cooldown > 0;
+      const dt = (newTime.getTime() - time.getTime()) / 1000;
+      time = newTime;
+
+      cooldown -= dt;
+
+      if (cooldown <= 0) {
+        if (shouldIncrementIndex) {
+          textIndex = (textIndex + 1) % texts.length;
+          if (text1Ref.current && text2Ref.current) {
+            text1Ref.current.textContent = texts[textIndex % texts.length];
+            text2Ref.current.textContent = texts[(textIndex + 1) % texts.length];
+          }
+        }
+        doMorph();
+      } else {
+        doCooldown();
+      }
+    }
+
+    animate();
+
+    return () => {
+      // Cleanup function if needed
+    };
+  }, [texts, morphTime, cooldownTime]);
+
+  return (
+    <div className={cn("relative", className)}>
+      <svg className="absolute h-0 w-0" aria-hidden="true" focusable="false">
+        <defs>
+          <filter id="threshold">
+            <feColorMatrix
+              in="SourceGraphic"
+              type="matrix"
+              values="1 0 0 0 0
+                      0 1 0 0 0
+                      0 0 1 0 0
+                      0 0 0 255 -140"
+            />
+          </filter>
+        </defs>
+      </svg>
+
+      <div
+        className="flex items-center justify-center"
+        style={{ filter: "url(#threshold)" }}
+      >
+        <span
+          ref={text1Ref}
+          className={cn(
+            "absolute inline-block select-none text-center text-6xl md:text-[60pt]",
+            "text-foreground",
+            textClassName
+          )}
+        />
+        <span
+          ref={text2Ref}
+          className={cn(
+            "absolute inline-block select-none text-center text-6xl md:text-[60pt]",
+            "text-foreground",
+            textClassName
+          )}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Added src/components/ui/gooey-text-morphing.tsx based on shadcn-like structure\n- Created demo component with lucide-react icons and unsplash images\n- Integrated demo into HomeRoute

---
*PR created automatically by Jules for task [11640783122730196361](https://jules.google.com/task/11640783122730196361) started by @guitarbeat*

## Summary by Sourcery

Integrate a reusable gooey text morphing UI component and showcase it on the home route with a themed demo section.

New Features:
- Add GooeyText component for animated, morphing text effects with configurable timing and styling.
- Introduce GooeyTextDemo showcasing the gooey text effect with iconography and background imagery on a card section of the home route.