### PR TITLE
🧪 Add tests for fetchHiddenNames and hiddenNamesQueryOptions

### DIFF
--- a/src/features/names/api.ts
+++ b/src/features/names/api.ts
@@ -1,10 +1,10 @@
-import { queryOptions } from "@tanstack/react-query";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { queryOptions } from "@tanstack/react-query";
 import type { Database } from "@/integrations/supabase/types";
 import { isRpcSignatureError } from "@/shared/lib/errors";
 import { mapNameRow } from "@/shared/lib/names/mapNameRow";
-import { resolveSupabaseClient, withSupabase } from "@/shared/services/supabase/runtime";
 import { throwOnFailureResponse } from "@/shared/services/supabase/errorUtils";
+import { resolveSupabaseClient, withSupabase } from "@/shared/services/supabase/runtime";
 import type { IdType, NameItem } from "@/shared/types";
 import useAppStore from "@/store/appStore";
 
@@ -15,15 +15,15 @@ import useAppStore from "@/store/appStore";
 export type NamesDataSource = "supabase";
 
 export interface NamesQueryResult {
-        names: NameItem[];
-        source: NamesDataSource;
+	names: NameItem[];
+	source: NamesDataSource;
 }
 
 export const namesQueryKeys = {
-        all: ["names"] as const,
-        lists: () => [...namesQueryKeys.all, "list"] as const,
-        list: (includeHidden: boolean) => [...namesQueryKeys.lists(), { includeHidden }] as const,
-        hiddenList: () => [...namesQueryKeys.all, "hidden"] as const,
+	all: ["names"] as const,
+	lists: () => [...namesQueryKeys.all, "list"] as const,
+	list: (includeHidden: boolean) => [...namesQueryKeys.lists(), { includeHidden }] as const,
+	hiddenList: () => [...namesQueryKeys.all, "hidden"] as const,
 } as const;
 
 const SUPABASE_UNAVAILABLE = Symbol("SUPABASE_UNAVAILABLE");
@@ -34,42 +34,42 @@ const SUPABASE_UNAVAILABLE = Symbol("SUPABASE_UNAVAILABLE");
 
 /** Verifies that the current user has admin privileges. */
 function assertAdmin(message = "Admin privileges required"): void {
-        const user = useAppStore.getState().user;
-        if (!user?.isAdmin) {
-                throw new Error(message);
-        }
+	const user = useAppStore.getState().user;
+	if (!user?.isAdmin) {
+		throw new Error(message);
+	}
 }
 
 async function runAdminMutation<T>(
-        operation: (client: SupabaseClient<Database>) => Promise<T>,
+	operation: (client: SupabaseClient<Database>) => Promise<T>,
 ): Promise<T> {
-        assertAdmin();
+	assertAdmin();
 
-        const result = await withSupabase<T | typeof SUPABASE_UNAVAILABLE>(
-                operation,
-                SUPABASE_UNAVAILABLE,
-        );
+	const result = await withSupabase<T | typeof SUPABASE_UNAVAILABLE>(
+		operation,
+		SUPABASE_UNAVAILABLE,
+	);
 
-        if (result === SUPABASE_UNAVAILABLE) {
-                throw new Error("Supabase client not available");
-        }
+	if (result === SUPABASE_UNAVAILABLE) {
+		throw new Error("Supabase client not available");
+	}
 
-        return result;
+	return result;
 }
 
 async function runBooleanAdminRpc(
-        rpcName: string,
-        args: Record<string, unknown>,
-        errorMessage: string,
+	rpcName: string,
+	args: Record<string, unknown>,
+	errorMessage: string,
 ): Promise<void> {
-        await runAdminMutation(async (client) => {
-                // @ts-expect-error - custom RPCs are not in generated types
-                const { data, error } = await client.rpc(rpcName, args);
-                if (error) {
-                        throw error;
-                }
-                throwOnFailureResponse(data, errorMessage);
-        });
+	await runAdminMutation(async (client) => {
+		// @ts-expect-error - custom RPCs are not in generated types
+		const { data, error } = await client.rpc(rpcName, args);
+		if (error) {
+			throw error;
+		}
+		throwOnFailureResponse(data, errorMessage);
+	});
 }
 
 // ============================================================================
@@ -77,230 +77,236 @@ async function runBooleanAdminRpc(
 // ============================================================================
 
 async function fetchNamesFromSupabase(includeHidden: boolean): Promise<NameItem[] | null> {
-        if (includeHidden) {
-                assertAdmin("Admin privileges required to view hidden names");
-        }
-        const client = await resolveSupabaseClient();
-        if (!client) {
-                return null;
-        }
+	if (includeHidden) {
+		assertAdmin("Admin privileges required to view hidden names");
+	}
+	const client = await resolveSupabaseClient();
+	if (!client) {
+		return null;
+	}
 
-        let query = client
-                .from("cat_names")
-                .select(
-                        "id, name, description, pronunciation, avg_rating, global_wins, global_losses, created_at, is_hidden, is_active, locked_in, status, provenance, is_deleted",
-                )
-                .eq("is_active", true)
-                .eq("is_deleted", false);
+	let query = client
+		.from("cat_names")
+		.select(
+			"id, name, description, pronunciation, avg_rating, global_wins, global_losses, created_at, is_hidden, is_active, locked_in, status, provenance, is_deleted",
+		)
+		.eq("is_active", true)
+		.eq("is_deleted", false);
 
-        if (!includeHidden) {
-                query = query.eq("is_hidden", false);
-        }
+	if (!includeHidden) {
+		query = query.eq("is_hidden", false);
+	}
 
-        const { data, error } = await query.order("avg_rating", { ascending: false });
-        if (error) {
-                throw error;
-        }
+	const { data, error } = await query.order("avg_rating", { ascending: false });
+	if (error) {
+		throw error;
+	}
 
-        return (data ?? []).map((row) => mapNameRow(row));
+	return (data ?? []).map((row) => mapNameRow(row));
 }
 
 export async function fetchHiddenNames(): Promise<NamesQueryResult> {
-        assertAdmin("Admin privileges required to view hidden names");
-        const client = await resolveSupabaseClient();
-        if (!client) {
-                throw new Error("Supabase client not available");
-        }
+	assertAdmin("Admin privileges required to view hidden names");
+	const client = await resolveSupabaseClient();
+	if (!client) {
+		throw new Error("Supabase client not available");
+	}
 
-        const { data, error } = await client
-                .from("cat_names")
-                .select(
-                        "id, name, description, pronunciation, avg_rating, global_wins, global_losses, created_at, is_hidden, is_active, locked_in, status, provenance, is_deleted",
-                )
-                .eq("is_hidden", true)
-                .eq("is_active", true)
-                .eq("is_deleted", false)
-                .order("avg_rating", { ascending: false });
+	const { data, error } = await client
+		.from("cat_names")
+		.select(
+			"id, name, description, pronunciation, avg_rating, global_wins, global_losses, created_at, is_hidden, is_active, locked_in, status, provenance, is_deleted",
+		)
+		.eq("is_hidden", true)
+		.eq("is_active", true)
+		.eq("is_deleted", false)
+		.order("avg_rating", { ascending: false });
 
-        if (error) {
-                throw error;
-        }
+	if (error) {
+		throw error;
+	}
 
-        return {
-                names: (data ?? []).map((row) => mapNameRow(row)),
-                source: "supabase",
-        };
+	return {
+		names: (data ?? []).map((row) => mapNameRow(row)),
+		source: "supabase",
+	};
 }
 
 export async function fetchNames(includeHidden: boolean): Promise<NamesQueryResult> {
-        const names = await fetchNamesFromSupabase(includeHidden);
-        if (names === null) {
-                throw new Error("Supabase client not available");
-        }
-        return { names, source: "supabase" };
+	const names = await fetchNamesFromSupabase(includeHidden);
+	if (names === null) {
+		throw new Error("Supabase client not available");
+	}
+	return { names, source: "supabase" };
 }
 
 export const namesQueryOptions = (includeHidden: boolean) =>
-        queryOptions({
-                queryKey: namesQueryKeys.list(includeHidden),
-                queryFn: () => fetchNames(includeHidden),
-                staleTime: 30_000,
-        });
+	queryOptions({
+		queryKey: namesQueryKeys.list(includeHidden),
+		queryFn: () => fetchNames(includeHidden),
+		staleTime: 30_000,
+	});
 
 export const hiddenNamesQueryOptions = () =>
-        queryOptions({
-                queryKey: namesQueryKeys.hiddenList(),
-                queryFn: () => fetchHiddenNames(),
-                staleTime: 30_000,
-        });
+	queryOptions({
+		queryKey: namesQueryKeys.hiddenList(),
+		queryFn: () => fetchHiddenNames(),
+		staleTime: 30_000,
+	});
 
 // ============================================================================
 // Mutations
 // ============================================================================
 
 export async function softDeleteName(params: { nameId: IdType }): Promise<void> {
-        const { nameId } = params;
-        await runBooleanAdminRpc(
-                "soft_delete_cat_name",
-                { p_name_id: String(nameId) },
-                "Failed to delete name",
-        );
+	const { nameId } = params;
+	await runBooleanAdminRpc(
+		"soft_delete_cat_name",
+		{ p_name_id: String(nameId) },
+		"Failed to delete name",
+	);
 }
 
 export async function batchUpdateVisibility(params: {
-        nameIds: IdType[];
-        isHidden: boolean;
+	nameIds: IdType[];
+	isHidden: boolean;
 }): Promise<void> {
-        const { nameIds, isHidden } = params;
-        await runBooleanAdminRpc(
-                "batch_update_name_visibility",
-                {
-                        p_name_ids: nameIds.map(String),
-                        p_is_hidden: isHidden,
-                },
-                "Failed to batch update name visibility",
-        );
+	const { nameIds, isHidden } = params;
+	await runBooleanAdminRpc(
+		"batch_update_name_visibility",
+		{
+			p_name_ids: nameIds.map(String),
+			p_is_hidden: isHidden,
+		},
+		"Failed to batch update name visibility",
+	);
 }
 
 export async function batchUpdateLocked(params: {
-        nameIds: IdType[];
-        isLocked: boolean;
+	nameIds: IdType[];
+	isLocked: boolean;
 }): Promise<void> {
-        const { nameIds, isLocked } = params;
-        await runBooleanAdminRpc(
-                "batch_update_name_locked",
-                {
-                        p_name_ids: nameIds.map(String),
-                        p_is_locked: isLocked,
-                },
-                "Failed to batch update name locked status",
-        );
+	const { nameIds, isLocked } = params;
+	await runBooleanAdminRpc(
+		"batch_update_name_locked",
+		{
+			p_name_ids: nameIds.map(String),
+			p_is_locked: isLocked,
+		},
+		"Failed to batch update name locked status",
+	);
 }
 
 export async function toggleNameHidden(params: {
-        nameId: IdType;
-        isCurrentlyHidden: boolean;
-        userName: string;
+	nameId: IdType;
+	isCurrentlyHidden: boolean;
+	userName: string;
 }): Promise<void> {
-        const { isCurrentlyHidden, nameId, userName } = params;
-        const trimmedUserName = userName.trim();
-        await runAdminMutation(async (client) => {
-                // @ts-expect-error - toggle_name_visibility is a custom RPC not in generated types
-                const { data, error } = await client.rpc("toggle_name_visibility", {
-                        p_name_id: String(nameId),
-                        p_hide: !isCurrentlyHidden,
-                        p_user_name: trimmedUserName || undefined,
-                });
-                if (error) {
-                        throw error;
-                }
-                throwOnFailureResponse(data, "Failed to update name visibility");
-        });
+	const { isCurrentlyHidden, nameId, userName } = params;
+	const trimmedUserName = userName.trim();
+	await runAdminMutation(async (client) => {
+		// @ts-expect-error - toggle_name_visibility is a custom RPC not in generated types
+		const { data, error } = await client.rpc("toggle_name_visibility", {
+			p_name_id: String(nameId),
+			p_hide: !isCurrentlyHidden,
+			p_user_name: trimmedUserName || undefined,
+		});
+		if (error) {
+			throw error;
+		}
+		throwOnFailureResponse(data, "Failed to update name visibility");
+	});
 }
 
 export async function toggleNameLocked(params: {
-        nameId: IdType;
-        isCurrentlyLocked: boolean;
-        userName: string;
+	nameId: IdType;
+	isCurrentlyLocked: boolean;
+	userName: string;
 }): Promise<void> {
-        const { isCurrentlyLocked, nameId, userName } = params;
-        const trimmedUserName = userName.trim();
-        await runAdminMutation(async (client) => {
-                const canonicalArgs = {
-                        p_name_id: String(nameId),
-                        p_locked_in: !isCurrentlyLocked,
-                };
-                let rpcResult = await client.rpc("toggle_name_locked_in", canonicalArgs);
+	const { isCurrentlyLocked, nameId, userName } = params;
+	const trimmedUserName = userName.trim();
+	await runAdminMutation(async (client) => {
+		const canonicalArgs = {
+			p_name_id: String(nameId),
+			p_locked_in: !isCurrentlyLocked,
+		};
+		let rpcResult = await client.rpc("toggle_name_locked_in", canonicalArgs);
 
-                if (rpcResult.error && isRpcSignatureError(rpcResult.error.message || "")) {
-                        rpcResult = await client.rpc("toggle_name_locked_in", {
-                                ...canonicalArgs,
-                                p_user_name: trimmedUserName,
-                        });
-                }
+		if (rpcResult.error && isRpcSignatureError(rpcResult.error.message || "")) {
+			rpcResult = await client.rpc("toggle_name_locked_in", {
+				...canonicalArgs,
+				p_user_name: trimmedUserName,
+			});
+		}
 
-                if (rpcResult.error) {
-                        throw new Error(rpcResult.error.message || "Failed to toggle locked status");
-                }
-                throwOnFailureResponse(rpcResult.data, "Failed to toggle locked status");
-        });
+		if (rpcResult.error) {
+			throw new Error(rpcResult.error.message || "Failed to toggle locked status");
+		}
+		throwOnFailureResponse(rpcResult.data, "Failed to toggle locked status");
+	});
 }
 
 export async function unhideAllNames(): Promise<void> {
-        await runAdminMutation(async (client) => {
-                // @ts-expect-error - unhide_all_names is a hypothetical RPC we might need
-                const { data: hiddenData, error: fetchError } = await client
-                        .from("cat_names")
-                        .select("id")
-                        .eq("is_hidden", true);
+	await runAdminMutation(async (client) => {
+		// @ts-expect-error - unhide_all_names is a hypothetical RPC we might need
+		const { data: hiddenData, error: fetchError } = await client
+			.from("cat_names")
+			.select("id")
+			.eq("is_hidden", true);
 
-                if (fetchError) {
-                        throw fetchError;
-                }
-                const hiddenIds = (hiddenData ?? []).map((row) => row.id);
+		if (fetchError) {
+			throw fetchError;
+		}
+		const hiddenIds = (hiddenData ?? []).map((row) => row.id);
 
-                if (hiddenIds.length === 0) {
-                        return true;
-                }
+		if (hiddenIds.length === 0) {
+			return true;
+		}
 
-                // @ts-expect-error - batch_update_name_visibility is a custom RPC
-                const { data, error } = await client.rpc("batch_update_name_visibility", {
-                        p_name_ids: hiddenIds.map(String),
-                        p_is_hidden: false,
-                });
-                if (error) {
-                        throw error;
-                }
-                throwOnFailureResponse(data, "Failed to unhide all names");
-        });
+		// @ts-expect-error - batch_update_name_visibility is a custom RPC
+		const { data, error } = await client.rpc("batch_update_name_visibility", {
+			p_name_ids: hiddenIds.map(String),
+			p_is_hidden: false,
+		});
+		if (error) {
+			throw error;
+		}
+		throwOnFailureResponse(data, "Failed to unhide all names");
+	});
 }
 
 export async function addName(params: { name: string; description?: string }): Promise<NameItem> {
-        return withSupabase(async (client) => {
-                const { data, error } = await client.rpc("add_cat_name", {
-                        p_name: params.name,
-                        p_description: params.description || "",
-                });
-                if (error) {
-                        throw new Error(error.message || "Failed to add name");
-                }
-                const row = Array.isArray(data) ? data[0] : data;
-                if (!row) {
-                        throw new Error("No data returned from add_cat_name");
-                }
-                return mapNameRow(row);
-        }, null);
+	return withSupabase(async (client) => {
+		const { data, error } = await client.rpc("add_cat_name", {
+			p_name: params.name,
+			p_description: params.description || "",
+		});
+		if (error) {
+			throw new Error(error.message || "Failed to add name");
+		}
+		const row = Array.isArray(data) ? data[0] : data;
+		if (!row) {
+			throw new Error("No data returned from add_cat_name");
+		}
+		return mapNameRow(row);
+	}, null);
 }
 
-export async function unhideName(userName: string, nameId: IdType): Promise<{ success: boolean; error?: string }> {
-        try {
-                await toggleNameHidden({
-                        nameId,
-                        isCurrentlyHidden: true, // We are unhiding, so currently it is hidden
-                        userName,
-                });
-                return { success: true };
-        } catch (error) {
-                return { success: false, error: error instanceof Error ? error.message : "Failed to unhide name" };
-        }
+export async function unhideName(
+	userName: string,
+	nameId: IdType,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		await toggleNameHidden({
+			nameId,
+			isCurrentlyHidden: true, // We are unhiding, so currently it is hidden
+			userName,
+		});
+		return { success: true };
+	} catch (error) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : "Failed to unhide name",
+		};
+	}
 }

--- a/src/features/names/queries.test.ts
+++ b/src/features/names/queries.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchNames, namesQueryKeys, namesQueryOptions } from "./api";
+import { fetchNames, fetchHiddenNames, namesQueryKeys, namesQueryOptions, hiddenNamesQueryOptions } from "./api";
 
 vi.mock("@/store/appStore", () => ({
 	default: {
@@ -85,6 +85,62 @@ describe("fetchNames", () => {
 	});
 });
 
+
+describe("fetchHiddenNames", () => {
+	it("throws when user is not an admin", async () => {
+		vi.mocked(useAppStore.getState).mockReturnValueOnce({
+			user: { isAdmin: false },
+		} as never);
+		await expect(fetchHiddenNames()).rejects.toThrow(
+			"Admin privileges required to view hidden names",
+		);
+	});
+
+	it("throws when Supabase client is unavailable", async () => {
+		vi.mocked(useAppStore.getState).mockReturnValue({
+			user: { isAdmin: true },
+		} as never);
+		vi.mocked(resolveSupabaseClient).mockResolvedValueOnce(null);
+		await expect(fetchHiddenNames()).rejects.toThrow(
+			"Supabase client not available",
+		);
+	});
+
+	it("allows admin to fetch hidden names", async () => {
+		vi.mocked(useAppStore.getState).mockReturnValue({
+			user: { isAdmin: true },
+		} as never);
+		vi.mocked(resolveSupabaseClient).mockResolvedValueOnce(mockClient as never);
+		mockFrom.mockReturnValue({ select: mockSelect });
+		mockSelect.mockReturnValue({ eq: mockEq });
+		// fetchHiddenNames chains three eq calls then an order
+		mockEq.mockReturnValue({ eq: mockEq, order: mockOrder });
+		mockOrder.mockResolvedValueOnce({ data: [{ id: "1", name: "Test", avg_rating: 1500, global_wins: 0, global_losses: 0, is_hidden: true, is_active: true, is_deleted: false }], error: null });
+
+		const result = await fetchHiddenNames();
+		expect(result).toBeDefined();
+		expect(result.names.length).toBe(1);
+	});
+
+	it("throws on database error", async () => {
+		vi.mocked(useAppStore.getState).mockReturnValue({
+			user: { isAdmin: true },
+		} as never);
+		vi.mocked(resolveSupabaseClient).mockResolvedValueOnce(mockClient as never);
+		mockFrom.mockReturnValue({ select: mockSelect });
+		mockSelect.mockReturnValue({ eq: mockEq });
+		mockEq.mockReturnValue({ eq: mockEq, order: mockOrder });
+		mockOrder.mockResolvedValueOnce({
+			data: null,
+			error: { message: "DB Error" },
+		});
+
+		await expect(fetchHiddenNames()).rejects.toMatchObject({
+			message: "DB Error",
+		});
+	});
+});
+
 describe("namesQueryKeys", () => {
 	it("returns correct keys", () => {
 		expect(namesQueryKeys.all).toEqual(["names"]);
@@ -102,6 +158,15 @@ describe("namesQueryOptions", () => {
 	it("returns correct options", () => {
 		const options = namesQueryOptions(false);
 		expect(options.queryKey).toEqual(namesQueryKeys.list(false));
+		expect(options.queryFn).toBeDefined();
+		expect(options.staleTime).toBe(30_000);
+	});
+});
+
+describe("hiddenNamesQueryOptions", () => {
+	it("returns correct options", () => {
+		const options = hiddenNamesQueryOptions();
+		expect(options.queryKey).toEqual(namesQueryKeys.hiddenList());
 		expect(options.queryFn).toBeDefined();
 		expect(options.staleTime).toBe(30_000);
 	});

--- a/src/features/names/queries.test.ts
+++ b/src/features/names/queries.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchNames, fetchHiddenNames, namesQueryKeys, namesQueryOptions, hiddenNamesQueryOptions } from "./api";
+import {
+	fetchHiddenNames,
+	fetchNames,
+	hiddenNamesQueryOptions,
+	namesQueryKeys,
+	namesQueryOptions,
+} from "./api";
 
 vi.mock("@/store/appStore", () => ({
 	default: {
@@ -64,9 +70,7 @@ describe("fetchNames", () => {
 
 	it("throws when Supabase client is unavailable", async () => {
 		vi.mocked(resolveSupabaseClient).mockResolvedValueOnce(null);
-		await expect(fetchNames(false)).rejects.toThrow(
-			"Supabase client not available",
-		);
+		await expect(fetchNames(false)).rejects.toThrow("Supabase client not available");
 	});
 
 	it("throws on database error", async () => {
@@ -85,7 +89,6 @@ describe("fetchNames", () => {
 	});
 });
 
-
 describe("fetchHiddenNames", () => {
 	it("throws when user is not an admin", async () => {
 		vi.mocked(useAppStore.getState).mockReturnValueOnce({
@@ -101,9 +104,7 @@ describe("fetchHiddenNames", () => {
 			user: { isAdmin: true },
 		} as never);
 		vi.mocked(resolveSupabaseClient).mockResolvedValueOnce(null);
-		await expect(fetchHiddenNames()).rejects.toThrow(
-			"Supabase client not available",
-		);
+		await expect(fetchHiddenNames()).rejects.toThrow("Supabase client not available");
 	});
 
 	it("allows admin to fetch hidden names", async () => {
@@ -115,7 +116,21 @@ describe("fetchHiddenNames", () => {
 		mockSelect.mockReturnValue({ eq: mockEq });
 		// fetchHiddenNames chains three eq calls then an order
 		mockEq.mockReturnValue({ eq: mockEq, order: mockOrder });
-		mockOrder.mockResolvedValueOnce({ data: [{ id: "1", name: "Test", avg_rating: 1500, global_wins: 0, global_losses: 0, is_hidden: true, is_active: true, is_deleted: false }], error: null });
+		mockOrder.mockResolvedValueOnce({
+			data: [
+				{
+					id: "1",
+					name: "Test",
+					avg_rating: 1500,
+					global_wins: 0,
+					global_losses: 0,
+					is_hidden: true,
+					is_active: true,
+					is_deleted: false,
+				},
+			],
+			error: null,
+		});
 
 		const result = await fetchHiddenNames();
 		expect(result).toBeDefined();
@@ -145,11 +160,7 @@ describe("namesQueryKeys", () => {
 	it("returns correct keys", () => {
 		expect(namesQueryKeys.all).toEqual(["names"]);
 		expect(namesQueryKeys.lists()).toEqual(["names", "list"]);
-		expect(namesQueryKeys.list(true)).toEqual([
-			"names",
-			"list",
-			{ includeHidden: true },
-		]);
+		expect(namesQueryKeys.list(true)).toEqual(["names", "list", { includeHidden: true }]);
 		expect(namesQueryKeys.hiddenList()).toEqual(["names", "hidden"]);
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing unit tests for the fetchHiddenNames API query logic in src/features/names/api.ts.
📊 **Coverage:** Covered scenarios include admin privilege checks, Supabase client availability errors, successful retrieval using chained Supabase query mock configurations, and handling of database errors. Also added tests for the hiddenNamesQueryOptions utility.
✨ **Result:** Increased test coverage for src/features/names/api.ts and ensured proper isolation and behavior of the fetchHiddenNames queries.

---
*PR created automatically by Jules for task [16179826806920198141](https://jules.google.com/task/16179826806920198141) started by @guitarbeat*

## Summary by Sourcery

Add unit tests covering fetchHiddenNames admin access control, Supabase client error handling, database error propagation, and hiddenNamesQueryOptions configuration.

Tests:
- Add tests verifying fetchHiddenNames enforces admin-only access and handles missing Supabase client failures.
- Add tests ensuring fetchHiddenNames correctly returns hidden names on successful Supabase queries and propagates database errors.
- Add tests confirming hiddenNamesQueryOptions returns the expected query key, query function, and staleTime configuration.