### PR TITLE
🧹 Remove use of any type in useTournamentUIState

### DIFF
--- a/src/features/tournament/hooks/useTournamentUIState.ts
+++ b/src/features/tournament/hooks/useTournamentUIState.ts
@@ -116,13 +116,16 @@ export function useTournamentUIState({
 			const sideData = (side: "left" | "right") => {
 				const participant = currentMatch[side];
 				const id = typeof participant === "object" ? String(participant.id) : String(participant);
-				const name =
-					currentMatch.mode === "2v2"
-						? ((currentMatch[side] as any).memberNames ?? []).join(" + ") ||
-							String((currentMatch[side] as any).id)
-						: typeof participant === "object" && "name" in participant
-							? participant.name
+				let name = "";
+				if (currentMatch.mode === "2v2") {
+					const teamParticipant = participant as { memberNames?: string[] };
+					name = (teamParticipant.memberNames ?? []).join(" + ") || id;
+				} else {
+					name =
+						typeof participant === "object" && "name" in participant
+							? String((participant as { name: string }).name)
 							: String(participant);
+				}
 				return { name, id, description: "", outcome: winnerId === id ? "winner" : "loser" };
 			};
 			try {


### PR DESCRIPTION
🎯 **What:** Removed instances of `any` casting in `useTournamentUIState.ts` when handling participant match sides in 2v2 versus 1v1 scenarios.
💡 **Why:** Relying on `any` bypasses TypeScript's safety mechanisms and makes the code harder to read. Converting the complex ternary into a more structured `if/else` and applying accurate type constraints ensures safe resolution of fallback values.
✅ **Verification:** Verified via `pnpm run check` and `pnpm run lint:types` that types are now safe.
✨ **Result:** Improved type-safety and reduced chance of runtime evaluation issues when properties are missing.

---
*PR created automatically by Jules for task [15327849719749686098](https://jules.google.com/task/15327849719749686098) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Replace loosely typed 2v2 participant name resolution with a typed branch that avoids use of `any` and centralizes fallback handling for participant identifiers.