### PR TITLE
🧹 chore: Remove unused handleUndo logic and swipeHistory state

### DIFF
--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -242,9 +242,6 @@ export function NameSelector() {
 	const [hiddenQuery, setHiddenQuery] = useState("");
 	const [hiddenShowSelectedOnly, setHiddenShowSelectedOnly] = useState(false);
 	const [hiddenRenderCount, setHiddenRenderCount] = useState(24);
-	const [swipeHistory, setSwipeHistory] = useState<
-		Array<{ id: IdType; direction: "left" | "right"; timestamp: number }>
-	>([]);
 	const deferredSync = useDeferredSync();
 	const namesQuery = useQuery({
 		...namesQueryOptions(isAdmin),
@@ -338,7 +335,6 @@ export function NameSelector() {
 
 	const markSwiped = useCallback((nameId: IdType, direction: "left" | "right") => {
 		setSwipedIds((prev) => addToSet(prev, nameId));
-		setSwipeHistory((prev) => [...prev, { id: nameId, direction, timestamp: Date.now() }]);
 	}, []);
 
 	const handleSwipe = useCallback(
@@ -395,33 +391,6 @@ export function NameSelector() {
 		},
 		[handleSwipe, updateDragState],
 	);
-
-	// Undo last swipe functionality
-	const _handleUndo = useCallback(() => {
-		if (swipeHistory.length === 0) {
-			return;
-		}
-
-		const lastSwipe = swipeHistory[swipeHistory.length - 1];
-		if (!lastSwipe) {
-			return;
-		}
-
-		setSwipeHistory((prev) => prev.slice(0, -1));
-		setSwipedIds((prev) => removeFromSet(prev, lastSwipe.id));
-
-		// If it was a right swipe, remove from selected names and sync with store
-		if (lastSwipe.direction === "right") {
-			setSelectedNames((prev) => {
-				const next = removeFromSet(prev, lastSwipe.id);
-				// Use deferred sync to prevent render cycle issue
-				deferredSync(() => syncSelectionToStore(next));
-				return next;
-			});
-		}
-
-		triggerHaptic();
-	}, [swipeHistory, syncSelectionToStore, triggerHaptic, deferredSync]);
 
 	const handleToggleHidden = useCallback(
 		async (nameId: IdType, isCurrentlyHidden: boolean) => {


### PR DESCRIPTION
🎯 **What:** Removed unused commented out logic `_handleUndo` and the unused variable `swipeHistory`.
💡 **Why:** `_handleUndo` was commented-out and its logic hasn't been in use. `swipeHistory` and its calls were also unnecessary since they were only utilized by `_handleUndo`, so I removed them to improve maintainability and avoid needless state tracking logic inside `markSwiped` on every swipe.
✅ **Verification:** Verified changes visually, using automated linter testing to ensure that we didn't break functionality.
✨ **Result:** A cleaner component, reduced complexity, and slightly improved performance by not updating the state of `swipeHistory`.

---
*PR created automatically by Jules for task [4716519390237323351](https://jules.google.com/task/4716519390237323351) started by @guitarbeat*

## Summary by Sourcery

Remove unused undo swipe logic and its associated swipe history state from the NameSelector component to simplify swipe handling.

Enhancements:
- Eliminate the unused swipeHistory state and related updates from swipe tracking.
- Remove the unused _handleUndo callback and its dependency on swipe history to reduce component complexity.