### PR TITLE
🧪 Add tests for createIdToNameMap

### DIFF
--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -327,7 +327,7 @@ export function NameSelector() {
 		[],
 	);
 
-	const markSwiped = useCallback((nameId: IdType, direction: "left" | "right") => {
+	const markSwiped = useCallback((nameId: IdType, _direction: "left" | "right") => {
 		setSwipedIds((prev) => addToSet(prev, nameId));
 	}, []);
 

--- a/src/features/tournament/utils/tournamentLogic.test.ts
+++ b/src/features/tournament/utils/tournamentLogic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Team } from "@/shared/types";
-import { createTeamsById } from "./tournamentLogic";
+import type { Team, NameItem } from "@/shared/types";
+import { createTeamsById, createIdToNameMap } from "./tournamentLogic";
 
 describe("createTeamsById", () => {
 	it("returns an empty map when given an empty array", () => {
@@ -30,5 +30,37 @@ describe("createTeamsById", () => {
 		expect(result).toBeInstanceOf(Map);
 		expect(result.size).toBe(1);
 		expect(result.get("team1")).toEqual(teamB);
+	});
+});
+
+
+describe("createIdToNameMap", () => {
+	it("returns an empty map when given an empty array", () => {
+		const result = createIdToNameMap([]);
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+
+	it("returns a map with names keyed by their stringified ID", () => {
+		const names: NameItem[] = [
+			{ id: "name1", name: "Name 1" },
+			{ id: 2, name: "Name 2" },
+		];
+		const result = createIdToNameMap(names);
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(2);
+		expect(result.get("name1")).toEqual(names[0]);
+		expect(result.get("2")).toEqual(names[1]);
+	});
+
+	it("overrides earlier names if duplicate IDs exist", () => {
+		const nameA: NameItem = { id: "name1", name: "Name 1" };
+		const nameB: NameItem = { id: "name1", name: "Name 2" };
+		const names: NameItem[] = [nameA, nameB];
+
+		const result = createIdToNameMap(names);
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(1);
+		expect(result.get("name1")).toEqual(nameB);
 	});
 });

--- a/src/features/tournament/utils/tournamentLogic.test.ts
+++ b/src/features/tournament/utils/tournamentLogic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Team, NameItem } from "@/shared/types";
-import { createTeamsById, createIdToNameMap } from "./tournamentLogic";
+import type { NameItem, Team } from "@/shared/types";
+import { createIdToNameMap, createTeamsById } from "./tournamentLogic";
 
 describe("createTeamsById", () => {
 	it("returns an empty map when given an empty array", () => {
@@ -32,7 +32,6 @@ describe("createTeamsById", () => {
 		expect(result.get("team1")).toEqual(teamB);
 	});
 });
-
 
 describe("createIdToNameMap", () => {
 	it("returns an empty map when given an empty array", () => {

--- a/src/shared/components/layout/ConfirmDialog.test.tsx
+++ b/src/shared/components/layout/ConfirmDialog.test.tsx
@@ -11,7 +11,9 @@ describe("ConfirmDialog", () => {
 				open={true}
 				title="Confirm action"
 				description="A confirmation is required."
-				onConfirm={() => {}}
+				onConfirm={() => {
+					/* no-op */
+				}}
 				onCancel={onCancel}
 			/>,
 		);

--- a/src/shared/components/layout/Modal.test.tsx
+++ b/src/shared/components/layout/Modal.test.tsx
@@ -23,7 +23,13 @@ function ModalHarness() {
 describe("Modal", () => {
 	it("renders when open and matches title", () => {
 		render(
-			<Modal title="Welcome" open={true} onClose={() => {}}>
+			<Modal
+				title="Welcome"
+				open={true}
+				onClose={() => {
+					/* no-op */
+				}}
+			>
 				<p>Modal Content</p>
 			</Modal>,
 		);
@@ -33,7 +39,13 @@ describe("Modal", () => {
 
 	it("does not render when closed", () => {
 		render(
-			<Modal title="Welcome" open={false} onClose={() => {}}>
+			<Modal
+				title="Welcome"
+				open={false}
+				onClose={() => {
+					/* no-op */
+				}}
+			>
 				<p>Modal Content</p>
 			</Modal>,
 		);

--- a/src/shared/components/ui/CinematicHero.tsx
+++ b/src/shared/components/ui/CinematicHero.tsx
@@ -141,7 +141,9 @@ export function CinematicHero({
 	tagline1 = "Pick the perfect",
 	tagline2 = "name for your cat.",
 	description = "Run a tournament, gather opinions, and find the name that fits. Fair, visual, and surprisingly fun.",
-	onCTA = () => {},
+	onCTA = () => {
+		/* no-op */
+	},
 	ctaLabel = "Start a tournament",
 	isScrollAnimated = true,
 	className,

--- a/src/shared/hooks/useAsyncData.ts
+++ b/src/shared/hooks/useAsyncData.ts
@@ -64,7 +64,7 @@ export function useAsyncData<T>(
 			isActive = false;
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, deps);
+	}, [...deps]);
 
 	return { data, isLoading, error, refresh: run };
 }


### PR DESCRIPTION
🎯 **What:** Added a missing test suite for the `createIdToNameMap` utility function in `src/features/tournament/utils/tournamentLogic.test.ts`. This was a simple pure mapping function that was completely untested.
📊 **Coverage:** Added 3 new tests covering empty arrays, standard valid lists of IDs (handling mapping by stringified id), and correctly handling duplicate IDs to ensure the final entry takes precedence.
✨ **Result:** Improved overall test coverage and reliability for foundational data transformation functions.

---
*PR created automatically by Jules for task [6576976666933669590](https://jules.google.com/task/6576976666933669590) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add test cases for createIdToNameMap covering empty input, mixed string/number IDs, and duplicate ID handling.