### PR TITLE
🧪 Add edge case tests for getFlameCount

### DIFF
--- a/src/features/tournament/utils/heat.test.ts
+++ b/src/features/tournament/utils/heat.test.ts
@@ -111,5 +111,21 @@ describe("heat utils", () => {
 		it("respects custom max value", () => {
 			expect(getFlameCount(10, 12)).toBe(12); // 10 * 1.2 = 12
 		});
+
+		it("handles negative streak values", () => {
+			expect(getFlameCount(-1)).toBe(3);
+			expect(getFlameCount(-5)).toBe(3);
+			expect(getFlameCount(-100)).toBe(3);
+		});
+
+		it("handles extremely large streak values within bounds", () => {
+			expect(getFlameCount(1000)).toBe(8); // Default max is 8
+			expect(getFlameCount(1000, 50)).toBe(50); // Custom max
+		});
+
+		it("handles cases where max is less than the lower bound of 3", () => {
+			expect(getFlameCount(5, 2)).toBe(2);
+			expect(getFlameCount(10, -5)).toBe(-5);
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `getFlameCount` edge case scenarios was addressed. Tests were missing for negative streaks, exceptionally large streaks that hit the capping maximum, and cases where custom maximum values conflict with the static minimum bound of `3`. 
📊 **Coverage:** The function is now fully tested across negative integers, extremely large numbers, and reversed/invalid bound limits (e.g., `max < 3`).
✨ **Result:** Improved test reliability and safety net allowing for confident future refactoring of tournament heat calculation logic.

---
*PR created automatically by Jules for task [7985851596226903599](https://jules.google.com/task/7985851596226903599) started by @guitarbeat*

## Summary by Sourcery

Expand test coverage for getFlameCount to better validate its behavior across edge-case streak values and bounds.

Tests:
- Add tests for negative streak values to ensure getFlameCount respects the minimum bound.
- Add tests for extremely large streak values to confirm results are capped at the configured maximum.
- Add tests for scenarios where the configured max is lower than the minimum bound to document and lock in current behavior.