### PR TITLE
🧪 [Testing Improvement] Add tests for bracket padding logic

### DIFF
--- a/src/features/tournament/utils/tournamentLogic.test.ts
+++ b/src/features/tournament/utils/tournamentLogic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Team } from "@/shared/types";
-import { createTeamsById } from "./tournamentLogic";
+import { createTeamsById, padForRound } from "./tournamentLogic";
 
 describe("createTeamsById", () => {
 	it("returns an empty map when given an empty array", () => {
@@ -30,5 +30,32 @@ describe("createTeamsById", () => {
 		expect(result).toBeInstanceOf(Map);
 		expect(result.size).toBe(1);
 		expect(result.get("team1")).toEqual(teamB);
+	});
+});
+
+describe("padForRound", () => {
+	it("returns the same array if it has 0 or 1 elements", () => {
+		expect(padForRound([], 1)).toEqual([]);
+		expect(padForRound(["a"], 1)).toEqual(["a"]);
+	});
+
+	it("returns the same array if its length is already a power of two", () => {
+		expect(padForRound(["a", "b"], 1)).toEqual(["a", "b"]);
+		expect(padForRound(["a", "b", "c", "d"], 1)).toEqual(["a", "b", "c", "d"]);
+	});
+
+	it("pads an array of 3 elements to 4 using BYE strings", () => {
+		const result = padForRound(["a", "b", "c"], 1);
+		expect(result.length).toBe(4);
+		expect(result).toEqual(["a", "b", "c", "__BYE__1_3"]);
+	});
+
+	it("pads an array of 5 elements to 8 using BYE strings with the correct round and index", () => {
+		const result = padForRound(["a", "b", "c", "d", "e"], 2);
+		expect(result.length).toBe(8);
+		expect(result).toEqual([
+			"a", "b", "c", "d", "e",
+			"__BYE__2_5", "__BYE__2_6", "__BYE__2_7"
+		]);
 	});
 });

--- a/src/features/tournament/utils/tournamentLogic.test.ts
+++ b/src/features/tournament/utils/tournamentLogic.test.ts
@@ -53,9 +53,6 @@ describe("padForRound", () => {
 	it("pads an array of 5 elements to 8 using BYE strings with the correct round and index", () => {
 		const result = padForRound(["a", "b", "c", "d", "e"], 2);
 		expect(result.length).toBe(8);
-		expect(result).toEqual([
-			"a", "b", "c", "d", "e",
-			"__BYE__2_5", "__BYE__2_6", "__BYE__2_7"
-		]);
+		expect(result).toEqual(["a", "b", "c", "d", "e", "__BYE__2_5", "__BYE__2_6", "__BYE__2_7"]);
 	});
 });

--- a/src/features/tournament/utils/tournamentLogic.ts
+++ b/src/features/tournament/utils/tournamentLogic.ts
@@ -121,7 +121,7 @@ function createBye(round: number, index: number): string {
 	return `${BYE_PREFIX}${round}_${index}`;
 }
 
-function padForRound(entrants: string[], round: number): string[] {
+export function padForRound(entrants: string[], round: number): string[] {
 	if (entrants.length <= 1) {
 		return entrants;
 	}


### PR DESCRIPTION
🎯 **What:** Testing gap addressed for the internal bracket padding function `padForRound`.

📊 **Coverage:** The function is now explicitly exported and tested for:
- 0 elements (empty arrays)
- 1 element
- Power-of-two validations (already valid sizes)
- Odd inputs padding correctly to the next power of 2 using BYE string increments.

✨ **Result:** Enhanced determinism and reliability for generating tournament brackets, with improved test suite coverage for bracket logic.

---
*PR created automatically by Jules for task [6175624061687436008](https://jules.google.com/task/6175624061687436008) started by @guitarbeat*

## Summary by Sourcery

Add direct tests for tournament bracket padding behavior and expose the padding helper for testing and reuse.

Enhancements:
- Export the padForRound helper from tournamentLogic to make its bracket padding logic reusable and testable.

Tests:
- Add unit tests covering padForRound behavior for empty, single-element, power-of-two, and non-power-of-two entrant arrays.