### PR TITLE
🧪 Add tests for matchHelpers logic

### DIFF
--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -327,7 +327,7 @@ export function NameSelector() {
 		[],
 	);
 
-	const markSwiped = useCallback((nameId: IdType, direction: "left" | "right") => {
+	const markSwiped = useCallback((nameId: IdType, _direction: "left" | "right") => {
 		setSwipedIds((prev) => addToSet(prev, nameId));
 	}, []);
 

--- a/src/features/tournament/utils/matchHelpers.test.ts
+++ b/src/features/tournament/utils/matchHelpers.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { getMatchSideId, getMatchSideName, extractMatchData } from "./matchHelpers";
+import type { Match, NameItem, Team } from "@/shared/types";
+
+describe("matchHelpers", () => {
+	const mockName1: NameItem = {
+		id: "n1",
+		name: "Fluffy",
+		description: "A very fluffy cat",
+		pronunciation: "Fluf-fee",
+	};
+
+	const mockName2: NameItem = {
+		id: "n2",
+		name: "Mittens",
+		description: "Has white paws",
+	};
+
+	const mockTeam1: Team = {
+		id: "t1",
+		memberIds: ["n1", "n2"],
+		memberNames: ["Fluffy", "Mittens"],
+	};
+
+	const mockTeam2: Team = {
+		id: "t2",
+		memberIds: ["n3", "n4"],
+		memberNames: ["Garfield", "Odie"],
+	};
+
+	const match1v1Objects: Match = {
+		mode: "1v1",
+		left: mockName1,
+		right: mockName2,
+	};
+
+	const match1v1Strings: Match = {
+		mode: "1v1",
+		left: "id1",
+		right: "id2",
+	};
+
+	const match2v2: Match = {
+		mode: "2v2",
+		left: mockTeam1,
+		right: mockTeam2,
+	};
+
+	describe("getMatchSideId", () => {
+		it("extracts id from an object participant", () => {
+			expect(getMatchSideId(match1v1Objects, "left")).toBe("n1");
+			expect(getMatchSideId(match1v1Objects, "right")).toBe("n2");
+		});
+
+		it("returns the string representation if participant is a string", () => {
+			expect(getMatchSideId(match1v1Strings, "left")).toBe("id1");
+			expect(getMatchSideId(match1v1Strings, "right")).toBe("id2");
+		});
+
+		it("extracts id from a team participant in 2v2", () => {
+			// team objects are objects too
+			expect(getMatchSideId(match2v2, "left")).toBe("t1");
+			expect(getMatchSideId(match2v2, "right")).toBe("t2");
+		});
+	});
+
+	describe("getMatchSideName", () => {
+		it("returns the name property for an object participant in 1v1", () => {
+			expect(getMatchSideName(match1v1Objects, "left")).toBe("Fluffy");
+			expect(getMatchSideName(match1v1Objects, "right")).toBe("Mittens");
+		});
+
+		it("returns the string itself for a string participant in 1v1", () => {
+			expect(getMatchSideName(match1v1Strings, "left")).toBe("id1");
+			expect(getMatchSideName(match1v1Strings, "right")).toBe("id2");
+		});
+
+		it("joins member names with '+' for team participants in 2v2", () => {
+			expect(getMatchSideName(match2v2, "left")).toBe("Fluffy + Mittens");
+			expect(getMatchSideName(match2v2, "right")).toBe("Garfield + Odie");
+		});
+	});
+
+	describe("extractMatchData", () => {
+		it("extracts match data properly for 1v1 with object participants", () => {
+			const data = extractMatchData(match1v1Objects);
+			expect(data).toEqual({
+				leftId: "n1",
+				rightId: "n2",
+				leftName: "Fluffy",
+				rightName: "Mittens",
+				leftMembers: ["Fluffy"],
+				rightMembers: ["Mittens"],
+				leftIsTeam: false,
+				rightIsTeam: false,
+				leftDescription: "A very fluffy cat",
+				rightDescription: "Has white paws",
+				leftPronunciation: "Fluf-fee",
+				rightPronunciation: undefined,
+			});
+		});
+
+		it("extracts match data properly for 1v1 with string participants", () => {
+			const data = extractMatchData(match1v1Strings);
+			expect(data).toEqual({
+				leftId: "id1",
+				rightId: "id2",
+				leftName: "id1",
+				rightName: "id2",
+				leftMembers: ["id1"],
+				rightMembers: ["id2"],
+				leftIsTeam: false,
+				rightIsTeam: false,
+				leftDescription: undefined,
+				rightDescription: undefined,
+				leftPronunciation: undefined,
+				rightPronunciation: undefined,
+			});
+		});
+
+		it("extracts match data properly for 2v2", () => {
+			const data = extractMatchData(match2v2);
+			expect(data).toEqual({
+				leftId: "t1",
+				rightId: "t2",
+				leftName: "Fluffy + Mittens",
+				rightName: "Garfield + Odie",
+				leftMembers: ["Fluffy", "Mittens"],
+				rightMembers: ["Garfield", "Odie"],
+				leftIsTeam: true,
+				rightIsTeam: true,
+			});
+		});
+	});
+});

--- a/src/features/tournament/utils/matchHelpers.test.ts
+++ b/src/features/tournament/utils/matchHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { getMatchSideId, getMatchSideName, extractMatchData } from "./matchHelpers";
 import type { Match, NameItem, Team } from "@/shared/types";
+import { extractMatchData, getMatchSideId, getMatchSideName } from "./matchHelpers";
 
 describe("matchHelpers", () => {
 	const mockName1: NameItem = {

--- a/src/shared/components/layout/ConfirmDialog.test.tsx
+++ b/src/shared/components/layout/ConfirmDialog.test.tsx
@@ -11,7 +11,9 @@ describe("ConfirmDialog", () => {
 				open={true}
 				title="Confirm action"
 				description="A confirmation is required."
-				onConfirm={() => {}}
+				onConfirm={() => {
+					/* noop */
+				}}
 				onCancel={onCancel}
 			/>,
 		);

--- a/src/shared/components/layout/Modal.test.tsx
+++ b/src/shared/components/layout/Modal.test.tsx
@@ -23,7 +23,13 @@ function ModalHarness() {
 describe("Modal", () => {
 	it("renders when open and matches title", () => {
 		render(
-			<Modal title="Welcome" open={true} onClose={() => {}}>
+			<Modal
+				title="Welcome"
+				open={true}
+				onClose={() => {
+					/* noop */
+				}}
+			>
 				<p>Modal Content</p>
 			</Modal>,
 		);
@@ -33,7 +39,13 @@ describe("Modal", () => {
 
 	it("does not render when closed", () => {
 		render(
-			<Modal title="Welcome" open={false} onClose={() => {}}>
+			<Modal
+				title="Welcome"
+				open={false}
+				onClose={() => {
+					/* noop */
+				}}
+			>
 				<p>Modal Content</p>
 			</Modal>,
 		);

--- a/src/shared/components/ui/CinematicHero.tsx
+++ b/src/shared/components/ui/CinematicHero.tsx
@@ -141,7 +141,9 @@ export function CinematicHero({
 	tagline1 = "Pick the perfect",
 	tagline2 = "name for your cat.",
 	description = "Run a tournament, gather opinions, and find the name that fits. Fair, visual, and surprisingly fun.",
-	onCTA = () => {},
+	onCTA = () => {
+		/* noop */
+	},
 	ctaLabel = "Start a tournament",
 	isScrollAnimated = true,
 	className,

--- a/src/shared/hooks/useAsyncData.ts
+++ b/src/shared/hooks/useAsyncData.ts
@@ -64,7 +64,7 @@ export function useAsyncData<T>(
 			isActive = false;
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, deps);
+	}, [...deps]);
 
 	return { data, isLoading, error, refresh: run };
 }


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `getMatchSideId`, `getMatchSideName`, and `extractMatchData` functions in `matchHelpers.ts`.
📊 **Coverage:** Covered 1v1 and 2v2 modes, handling both string-based participants and object-based participants (`NameItem`, `Team`).
✨ **Result:** Increased test coverage for tournament matching utilities, ensuring safer refactoring and increased reliability.

---
*PR created automatically by Jules for task [1607731304716890398](https://jules.google.com/task/1607731304716890398) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add tests for getMatchSideId, getMatchSideName, and extractMatchData covering 1v1 and 2v2 modes with string and object-based participants.