### PR TITLE
🧪 Add tests for resolveCurrentMatch in tournament logic

### DIFF
--- a/src/features/tournament/utils/tournamentLogic.test.ts
+++ b/src/features/tournament/utils/tournamentLogic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Team } from "@/shared/types";
-import { createTeamsById } from "./tournamentLogic";
+import type { NameItem, Team } from "@/shared/types";
+import { createTeamsById, resolveCurrentMatch } from "./tournamentLogic";
 
 describe("createTeamsById", () => {
 	it("returns an empty map when given an empty array", () => {
@@ -30,5 +30,95 @@ describe("createTeamsById", () => {
 		expect(result).toBeInstanceOf(Map);
 		expect(result.size).toBe(1);
 		expect(result.get("team1")).toEqual(teamB);
+	});
+});
+
+describe("resolveCurrentMatch", () => {
+	const mockTeamsById = new Map<string, Team>([
+		["team1", { id: "team1", memberIds: ["user1"], memberNames: ["User 1"] }],
+		["team2", { id: "team2", memberIds: ["user2"], memberNames: ["User 2"] }],
+	]);
+
+	const mockIdToNameMap = new Map<string, NameItem>([
+		["name1", { id: "name1", name: "Fluffy" } as NameItem],
+		["name2", { id: "name2", name: "Mittens" } as NameItem],
+	]);
+
+	it("returns null if pendingMatchIds is null", () => {
+		expect(
+			resolveCurrentMatch({
+				tournamentMode: "1v1",
+				pendingMatchIds: null,
+				teamsById: mockTeamsById,
+				idToNameMap: mockIdToNameMap,
+			}),
+		).toBeNull();
+	});
+
+	it("resolves 1v1 match correctly when names exist in map", () => {
+		const match = resolveCurrentMatch({
+			tournamentMode: "1v1",
+			pendingMatchIds: { leftId: "name1", rightId: "name2" },
+			teamsById: mockTeamsById,
+			idToNameMap: mockIdToNameMap,
+		});
+
+		expect(match).toEqual({
+			mode: "1v1",
+			left: { id: "name1", name: "Fluffy" },
+			right: { id: "name2", name: "Mittens" },
+		});
+	});
+
+	it("resolves 1v1 match with fallback objects when names do not exist in map", () => {
+		const match = resolveCurrentMatch({
+			tournamentMode: "1v1",
+			pendingMatchIds: { leftId: "unknown1", rightId: "unknown2" },
+			teamsById: mockTeamsById,
+			idToNameMap: mockIdToNameMap,
+		});
+
+		expect(match).toEqual({
+			mode: "1v1",
+			left: { id: "unknown1", name: "unknown1" },
+			right: { id: "unknown2", name: "unknown2" },
+		});
+	});
+
+	it("resolves 2v2 match correctly when teams exist in map", () => {
+		const match = resolveCurrentMatch({
+			tournamentMode: "2v2",
+			pendingMatchIds: { leftId: "team1", rightId: "team2" },
+			teamsById: mockTeamsById,
+			idToNameMap: mockIdToNameMap,
+		});
+
+		expect(match).toEqual({
+			mode: "2v2",
+			left: { id: "team1", memberIds: ["user1"], memberNames: ["User 1"] },
+			right: { id: "team2", memberIds: ["user2"], memberNames: ["User 2"] },
+		});
+	});
+
+	it("returns null for 2v2 mode when left team does not exist", () => {
+		const match = resolveCurrentMatch({
+			tournamentMode: "2v2",
+			pendingMatchIds: { leftId: "unknown", rightId: "team2" },
+			teamsById: mockTeamsById,
+			idToNameMap: mockIdToNameMap,
+		});
+
+		expect(match).toBeNull();
+	});
+
+	it("returns null for 2v2 mode when right team does not exist", () => {
+		const match = resolveCurrentMatch({
+			tournamentMode: "2v2",
+			pendingMatchIds: { leftId: "team1", rightId: "unknown" },
+			teamsById: mockTeamsById,
+			idToNameMap: mockIdToNameMap,
+		});
+
+		expect(match).toBeNull();
 	});
 });


### PR DESCRIPTION
🎯 **What:** The `resolveCurrentMatch` function in `src/features/tournament/utils/tournamentLogic.ts` lacked tests. It maps out current 1v1 and 2v2 modes.
📊 **Coverage:** Successfully added comprehensive unit tests to evaluate its core functionalities:
- Edge case: return `null` if `pendingMatchIds` is `null`.
- 1v1 Mode: ensure match is resolved successfully when name map works.
- 1v1 Mode: verify fallback behavior for missing name maps.
- 2v2 Mode: ensure correct behavior mapping teams appropriately.
- 2v2 Mode: ensure `null` return if missing the left or right team ids inside the map.
✨ **Result:** Test coverage improved specifically resolving untested code in `tournamentLogic.ts` to improve system robustness.

---
*PR created automatically by Jules for task [18328488794270971830](https://jules.google.com/task/18328488794270971830) started by @guitarbeat*

## Summary by Sourcery

Add unit test coverage for the resolveCurrentMatch tournament utility across supported modes and edge cases.

Tests:
- Add tests for resolveCurrentMatch handling null pendingMatchIds.
- Add tests for 1v1 mode covering successful name resolution and fallback behavior when names are missing.
- Add tests for 2v2 mode covering successful team resolution and null returns when either team is missing.