### PR TITLE
🧪 Add tests for extractMatchData in matchHelpers

### DIFF
--- a/src/features/tournament/utils/matchHelpers.test.ts
+++ b/src/features/tournament/utils/matchHelpers.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import type { HeadToHeadMatch, TeamVersusMatch } from "@/shared/types";
 import { extractMatchData, getMatchSideId, getMatchSideName } from "./matchHelpers";
-import type { Match, HeadToHeadMatch, TeamVersusMatch } from "@/shared/types";
 
 describe("matchHelpers", () => {
 	describe("extractMatchData", () => {

--- a/src/features/tournament/utils/matchHelpers.test.ts
+++ b/src/features/tournament/utils/matchHelpers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { extractMatchData, getMatchSideId, getMatchSideName } from "./matchHelpers";
+import type { Match, HeadToHeadMatch, TeamVersusMatch } from "@/shared/types";
+
+describe("matchHelpers", () => {
+	describe("extractMatchData", () => {
+		it("extracts data from a 2v2 match", () => {
+			const match: TeamVersusMatch = {
+				mode: "2v2",
+				left: {
+					id: "team-1",
+					memberIds: ["p1", "p2"],
+					memberNames: ["Player One", "Player Two"],
+				},
+				right: {
+					id: "team-2",
+					memberIds: ["p3", "p4"],
+					memberNames: ["Player Three", "Player Four"],
+				},
+			};
+
+			const result = extractMatchData(match);
+
+			expect(result).toEqual({
+				leftId: "team-1",
+				rightId: "team-2",
+				leftName: "Player One + Player Two",
+				rightName: "Player Three + Player Four",
+				leftMembers: ["Player One", "Player Two"],
+				rightMembers: ["Player Three", "Player Four"],
+				leftIsTeam: true,
+				rightIsTeam: true,
+			});
+		});
+
+		it("extracts data from a 1v1 match with NameItem objects", () => {
+			const match: HeadToHeadMatch = {
+				mode: "1v1",
+				left: {
+					id: "item-1",
+					name: "Name One",
+					description: "First description",
+					pronunciation: "pro-NUN-see-a-shun 1",
+				},
+				right: {
+					id: "item-2",
+					name: "Name Two",
+					description: "Second description",
+				},
+			};
+
+			const result = extractMatchData(match);
+
+			expect(result).toEqual({
+				leftId: "item-1",
+				rightId: "item-2",
+				leftName: "Name One",
+				rightName: "Name Two",
+				leftMembers: ["Name One"],
+				rightMembers: ["Name Two"],
+				leftIsTeam: false,
+				rightIsTeam: false,
+				leftDescription: "First description",
+				rightDescription: "Second description",
+				leftPronunciation: "pro-NUN-see-a-shun 1",
+				rightPronunciation: undefined,
+			});
+		});
+
+		it("extracts data from a 1v1 match with string participants", () => {
+			const match: HeadToHeadMatch = {
+				mode: "1v1",
+				left: "String One",
+				right: "String Two",
+			};
+
+			const result = extractMatchData(match);
+
+			expect(result).toEqual({
+				leftId: "String One",
+				rightId: "String Two",
+				leftName: "String One",
+				rightName: "String Two",
+				leftMembers: ["String One"],
+				rightMembers: ["String Two"],
+				leftIsTeam: false,
+				rightIsTeam: false,
+				leftDescription: undefined,
+				rightDescription: undefined,
+				leftPronunciation: undefined,
+				rightPronunciation: undefined,
+			});
+		});
+	});
+
+	describe("getMatchSideId", () => {
+		it("returns id from NameItem participant", () => {
+			const match: HeadToHeadMatch = {
+				mode: "1v1",
+				left: { id: "left-id", name: "Left Name" },
+				right: { id: "right-id", name: "Right Name" },
+			};
+			expect(getMatchSideId(match, "left")).toBe("left-id");
+			expect(getMatchSideId(match, "right")).toBe("right-id");
+		});
+
+		it("returns string value from string participant", () => {
+			const match: HeadToHeadMatch = {
+				mode: "1v1",
+				left: "left-string",
+				right: "right-string",
+			};
+			expect(getMatchSideId(match, "left")).toBe("left-string");
+			expect(getMatchSideId(match, "right")).toBe("right-string");
+		});
+	});
+
+	describe("getMatchSideName", () => {
+		it("returns joined member names for 2v2 mode", () => {
+			const match: TeamVersusMatch = {
+				mode: "2v2",
+				left: { id: "t1", memberIds: [], memberNames: ["A", "B"] },
+				right: { id: "t2", memberIds: [], memberNames: ["C", "D"] },
+			};
+			expect(getMatchSideName(match, "left")).toBe("A + B");
+			expect(getMatchSideName(match, "right")).toBe("C + D");
+		});
+
+		it("returns name from NameItem participant", () => {
+			const match: HeadToHeadMatch = {
+				mode: "1v1",
+				left: { id: "1", name: "Left Name" },
+				right: { id: "2", name: "Right Name" },
+			};
+			expect(getMatchSideName(match, "left")).toBe("Left Name");
+			expect(getMatchSideName(match, "right")).toBe("Right Name");
+		});
+
+		it("returns string value from string participant", () => {
+			const match: HeadToHeadMatch = {
+				mode: "1v1",
+				left: "Left String",
+				right: "Right String",
+			};
+			expect(getMatchSideName(match, "left")).toBe("Left String");
+			expect(getMatchSideName(match, "right")).toBe("Right String");
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap in `extractMatchData` was addressed by writing unit tests for its parsing behavior. Added coverage to sibling utilities `getMatchSideId` and `getMatchSideName`.
📊 **Coverage:** Tests now cover 2v2 modes handling `Team` inputs with joining member names, as well as 1v1 modes with complex `NameItem` objects and plain `string` participants.
✨ **Result:** Test coverage for `matchHelpers` logic is fully verified across 8 unit tests in the new test suite.

---
*PR created automatically by Jules for task [1761897340347520474](https://jules.google.com/task/1761897340347520474) started by @guitarbeat*

## Summary by Sourcery

Add a new test suite to validate match helper parsing behavior.

Tests:
- Add unit tests for extractMatchData covering 2v2 and 1v1 modes with varied participant representations.
- Add tests for getMatchSideId and getMatchSideName to ensure correct side resolution from match data.