### PR TITLE
🧪 testing improvement for getHeatGradientClasses fallback

### DIFF
--- a/src/features/tournament/utils/heat.test.ts
+++ b/src/features/tournament/utils/heat.test.ts
@@ -70,6 +70,11 @@ describe("heat utils", () => {
 				"text-orange-100 border-orange-300/35 bg-orange-500/10",
 			);
 		});
+		it("returns default classes for invalid/unknown inputs", () => {
+			expect(getHeatTextClasses("unknown" as any)).toBe(
+				"text-orange-100 border-orange-300/35 bg-orange-500/10",
+			);
+		});
 	});
 
 	describe("getHeatGradientClasses", () => {
@@ -87,6 +92,11 @@ describe("heat utils", () => {
 
 		it('returns correct classes for "warm"', () => {
 			expect(getHeatGradientClasses("warm")).toBe(
+				"bg-gradient-to-t from-orange-500/20 via-amber-200/10 to-transparent",
+			);
+		});
+		it("returns default classes for invalid/unknown inputs", () => {
+			expect(getHeatGradientClasses("unknown" as any)).toBe(
 				"bg-gradient-to-t from-orange-500/20 via-amber-200/10 to-transparent",
 			);
 		});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the default/fallback branches of the `getHeatGradientClasses` and `getHeatTextClasses` switch statements when handling invalid runtime string parameters that bypass TypeScript validations.

📊 **Coverage:** We explicitly cover scenarios where inputs evaluate to the default case via `'unknown' as any`.

✨ **Result:** Assures the UI components don't crash and default properly to safe baseline styling when encountering unpredictably formatted inputs.

---
*PR created automatically by Jules for task [116078796523347454](https://jules.google.com/task/116078796523347454) started by @guitarbeat*

## Summary by Sourcery

Add tests to ensure heat styling utilities fall back to default classes for invalid inputs.

Tests:
- Add coverage for getHeatTextClasses to verify it returns default classes when given an unknown input value.
- Add coverage for getHeatGradientClasses to verify it returns default classes when given an unknown input value.