### PR TITLE
🧪 Add unit tests for usePersonalResults hook

### DIFF
--- a/src/features/analytics/hooks/usePersonalResults.test.ts
+++ b/src/features/analytics/hooks/usePersonalResults.test.ts
@@ -1,0 +1,130 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ELO_RATING } from "@/shared/lib/constants";
+import { usePersonalResults } from "./usePersonalResults";
+
+describe("usePersonalResults", () => {
+	it("returns empty rankings when personalRatings is undefined", () => {
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings: undefined,
+			}),
+		);
+		expect(result.current.rankings).toEqual([]);
+	});
+
+	it("processes and sorts personalRatings correctly without currentTournamentNames", () => {
+		const personalRatings = {
+			"id-1": { rating: 1200, wins: 5, losses: 2 },
+			"id-2": { rating: 1500, wins: 10, losses: 5 },
+			"id-3": { rating: 1000, wins: 1, losses: 8 },
+		};
+
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings,
+			}),
+		);
+
+		expect(result.current.rankings).toEqual([
+			{ id: "id-2", name: "id-2", rating: 1500, wins: 10, losses: 5 },
+			{ id: "id-1", name: "id-1", rating: 1200, wins: 5, losses: 2 },
+			{ id: "id-3", name: "id-3", rating: 1000, wins: 1, losses: 8 },
+		]);
+	});
+
+	it("maps names from currentTournamentNames when available", () => {
+		const personalRatings = {
+			"id-1": { rating: 1200, wins: 5, losses: 2 },
+			"id-2": { rating: 1500, wins: 10, losses: 5 },
+		};
+
+		const currentTournamentNames = [
+			{ id: "id-1", name: "Alpha", rating: 1100, wins: 0, losses: 0 },
+			{ id: "id-2", name: "Beta", rating: 1400, wins: 0, losses: 0 },
+		];
+
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings,
+				currentTournamentNames,
+			}),
+		);
+
+		expect(result.current.rankings).toEqual([
+			{ id: "id-2", name: "Beta", rating: 1500, wins: 10, losses: 5 },
+			{ id: "id-1", name: "Alpha", rating: 1200, wins: 5, losses: 2 },
+		]);
+	});
+
+	it("handles number values in personalRatings instead of objects", () => {
+		const personalRatings = {
+			"id-1": 1300,
+			"id-2": 1600,
+		};
+
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings,
+			}),
+		);
+
+		expect(result.current.rankings).toEqual([
+			{ id: "id-2", name: "id-2", rating: 1600, wins: 0, losses: 0 },
+			{ id: "id-1", name: "id-1", rating: 1300, wins: 0, losses: 0 },
+		]);
+	});
+
+	it("uses default rating when rating is missing from object", () => {
+		const personalRatings = {
+			"id-1": { wins: 5, losses: 2 },
+		};
+
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings,
+			}),
+		);
+
+		expect(result.current.rankings).toEqual([
+			{ id: "id-1", name: "id-1", rating: ELO_RATING.DEFAULT_RATING, wins: 5, losses: 2 },
+		]);
+	});
+
+	it("ignores currentTournamentNames without id", () => {
+		const personalRatings = {
+			"id-1": { rating: 1200, wins: 5, losses: 2 },
+		};
+
+		const currentTournamentNames = [{ name: "Alpha", rating: 1100, wins: 0, losses: 0 }];
+
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings,
+				currentTournamentNames,
+			}),
+		);
+
+		expect(result.current.rankings).toEqual([
+			{ id: "id-1", name: "id-1", rating: 1200, wins: 5, losses: 2 },
+		]);
+	});
+
+	it("rounds ratings correctly", () => {
+		const personalRatings = {
+			"id-1": { rating: 1200.4, wins: 5, losses: 2 },
+			"id-2": { rating: 1500.6, wins: 10, losses: 5 },
+		};
+
+		const { result } = renderHook(() =>
+			usePersonalResults({
+				personalRatings,
+			}),
+		);
+
+		expect(result.current.rankings).toEqual([
+			{ id: "id-2", name: "id-2", rating: 1501, wins: 10, losses: 5 },
+			{ id: "id-1", name: "id-1", rating: 1200, wins: 5, losses: 2 },
+		]);
+	});
+});

--- a/src/shared/components/profile/ProfileInner.test.tsx
+++ b/src/shared/components/profile/ProfileInner.test.tsx
@@ -68,9 +68,11 @@ describe("ProfileInner", () => {
 		await waitFor(() => {
 			expect(onLogin).toHaveBeenCalledWith("Ada");
 		});
-		expect(
-			screen.getByText("We couldn't log you in with that name. Try again."),
-		).toBeInTheDocument();
+		await waitFor(() => {
+			expect(
+				screen.getByText("We couldn't log you in with that name. Try again."),
+			).toBeInTheDocument();
+		});
 		expect(screen.getByRole("button", { name: "Begin Journey" })).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `usePersonalResults` hook which was previously untested.
📊 **Coverage:** Added tests covering:
- Handling of undefined/empty input
- Correct mapping and sorting of ratings based on their Elo score
- Properly mapping IDs to actual names when `currentTournamentNames` array is passed
- Correct fallback behavior handling raw numbers instead of objects
- Edge cases including missing IDs, utilizing `DEFAULT_RATING` when rating is missing, and mathematically correct rounding of scores
✨ **Result:** Increased test coverage for the analytics feature, validating that hook logic for extracting arrays correctly calculates and merges data properties while protecting against regressions.

---
*PR created automatically by Jules for task [11114651077864604904](https://jules.google.com/task/11114651077864604904) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add comprehensive unit tests for usePersonalResults covering empty input, ID/name mapping, rating fallbacks, sorting, and edge cases.