### PR TITLE
🧪 [testing] add tests for deriveBracketState

### DIFF
--- a/src/features/tournament/utils/tournamentLogic.test.ts
+++ b/src/features/tournament/utils/tournamentLogic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Team } from "@/shared/types";
-import { createTeamsById } from "./tournamentLogic";
+import type { MatchRecord, Team } from "@/shared/types";
+import { createTeamsById, deriveBracketState } from "./tournamentLogic";
 
 describe("createTeamsById", () => {
 	it("returns an empty map when given an empty array", () => {
@@ -30,5 +30,119 @@ describe("createTeamsById", () => {
 		expect(result).toBeInstanceOf(Map);
 		expect(result.size).toBe(1);
 		expect(result.get("team1")).toEqual(teamB);
+	});
+});
+
+describe("deriveBracketState", () => {
+	function mockRecord(winner: string): MatchRecord {
+		return {
+			match: { mode: "1v1", left: "any", right: "any" } as any,
+			winner,
+			loser: "any",
+			voteType: "manual",
+			matchNumber: 1,
+			roundNumber: 1,
+			timestamp: Date.now(),
+		};
+	}
+
+	it("returns a completed state for 1 entrant", () => {
+		const result = deriveBracketState(["a"], []);
+		expect(result).toEqual({
+			isComplete: true,
+			totalMatches: 0,
+			completedMatches: 0,
+			round: 1,
+			totalRounds: 1,
+			stageLabel: "Final",
+			roundSize: 1,
+			pendingMatchIds: null,
+		});
+	});
+
+	it("returns an initial state for 4 entrants with no history", () => {
+		const result = deriveBracketState(["a", "b", "c", "d"], []);
+		expect(result).toEqual({
+			isComplete: false,
+			totalMatches: 3,
+			completedMatches: 0,
+			round: 1,
+			totalRounds: 2,
+			stageLabel: "Semifinal",
+			roundSize: 4,
+			pendingMatchIds: { leftId: "a", rightId: "b" },
+		});
+	});
+
+	it("returns a pending state when history has fewer records than total matches", () => {
+		const result = deriveBracketState(["a", "b", "c", "d"], [mockRecord("a")]);
+		expect(result).toEqual({
+			isComplete: false,
+			totalMatches: 3,
+			completedMatches: 1,
+			round: 1,
+			totalRounds: 2,
+			stageLabel: "Semifinal",
+			roundSize: 4,
+			pendingMatchIds: { leftId: "c", rightId: "d" },
+		});
+	});
+
+	it("returns a completed state when history covers all matches", () => {
+		const result = deriveBracketState(
+			["a", "b", "c", "d"],
+			[mockRecord("a"), mockRecord("c"), mockRecord("a")],
+		);
+		expect(result.isComplete).toBe(true);
+		expect(result.completedMatches).toBe(3);
+		expect(result.pendingMatchIds).toBeNull();
+	});
+
+	it("handles corrupted history by returning a pending match", () => {
+		// First match a vs b, history says 'x' won which doesn't match either side
+		const result = deriveBracketState(["a", "b", "c", "d"], [mockRecord("x")]);
+		expect(result.isComplete).toBe(false);
+		expect(result.completedMatches).toBe(0); // Ignores the corrupted record
+		expect(result.pendingMatchIds).toEqual({ leftId: "a", rightId: "b" });
+	});
+
+	it("handles non-power-of-two entrants using byes", () => {
+		const result = deriveBracketState(["a", "b", "c"], []);
+		expect(result).toEqual({
+			isComplete: false,
+			totalMatches: 2,
+			completedMatches: 0,
+			round: 1,
+			totalRounds: 2,
+			stageLabel: "Semifinal",
+			roundSize: 3,
+			pendingMatchIds: { leftId: "a", rightId: "b" },
+		});
+
+		// Match 1: a vs b, winner a
+		const step2 = deriveBracketState(["a", "b", "c"], [mockRecord("a")]);
+		expect(step2).toEqual({
+			isComplete: false,
+			totalMatches: 2,
+			completedMatches: 1,
+			round: 2,
+			totalRounds: 2,
+			stageLabel: "Final",
+			roundSize: 2,
+			pendingMatchIds: { leftId: "a", rightId: "c" },
+		});
+	});
+
+	it("caches results for the same inputs", () => {
+		const entrants = ["a", "b", "c", "d"];
+		const result1 = deriveBracketState(entrants, []);
+		const result2 = deriveBracketState(entrants, []);
+		expect(result1).toBe(result2); // Exact same object reference
+
+		const history = [mockRecord("b")];
+		const result3 = deriveBracketState(entrants, history);
+		const result4 = deriveBracketState(entrants, history);
+		expect(result3).toBe(result4);
+		expect(result3).not.toBe(result1);
 	});
 });

--- a/src/features/tournament/utils/tournamentLogic.ts
+++ b/src/features/tournament/utils/tournamentLogic.ts
@@ -60,8 +60,9 @@ function makePendingResult(
 	activeRoundSize: number,
 	left: string,
 	right: string,
+	cacheKey?: string,
 ): BracketDerivation {
-	return {
+	const result = {
 		isComplete: false,
 		totalMatches,
 		completedMatches: cursor,
@@ -71,6 +72,10 @@ function makePendingResult(
 		roundSize: activeRoundSize,
 		pendingMatchIds: { leftId: left, rightId: right },
 	};
+	if (cacheKey) {
+		return setBracketCache(cacheKey, result);
+	}
+	return result;
 }
 
 function getCacheKey(bracketEntrants: string[], matchHistory: MatchRecord[]): string {
@@ -235,6 +240,7 @@ export function deriveBracketState(
 					activeRoundSize,
 					left,
 					right,
+					cacheKey,
 				);
 			}
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `deriveBracketState` function in `src/features/tournament/utils/tournamentLogic.ts` lacked unit tests. It is a critical piece of logic that caches state, handles padding using byes for non-power-of-two entrants, processes corrupted match histories, and calculates tournament rounds.

📊 **Coverage:** What scenarios are now tested
- Returning a completed state for 1 entrant.
- Initial state for 4 entrants with no history.
- Pending state when history has fewer records than total matches.
- Completed state when history covers all matches.
- Error handling: gracefully identifying corrupted history (when the recorded winner matches neither side), ignoring the bad record, and returning a pending match object to wait for user re-vote.
- Byes: handling non-power-of-two entrants properly, checking caching outputs across multiple iterations.
- Caching: verifying that passing identical input dependencies returns the exact same object reference.
*(Also caught and fixed a small bug where pending outcomes weren't actually being pushed into the memory cache via `setBracketCache`)*

✨ **Result:** The improvement in test coverage
The critical `deriveBracketState` algorithmic pathway is now fully validated and robust. Test suites pass successfully.

---
*PR created automatically by Jules for task [17583091997193579068](https://jules.google.com/task/17583091997193579068) started by @guitarbeat*

## Summary by Sourcery

Add unit tests for the tournament bracket derivation logic and ensure pending bracket states are correctly cached.

Bug Fixes:
- Fix bracket caching so pending outcomes produced by makePendingResult are stored in the cache when a cache key is provided.

Tests:
- Add comprehensive tests for deriveBracketState covering single-entrant completion, initial and pending states, full completion, corrupted histories, non-power-of-two entrants with byes, and caching behavior.