### PR TITLE
test: add unit tests for filterNamesByStatusAndSearch

### DIFF
--- a/src/features/admin/AdminDashboard.tsx
+++ b/src/features/admin/AdminDashboard.tsx
@@ -12,7 +12,7 @@ import {
 	buildAdminStats,
 	filterNamesByStatusAndSearch,
 	mapNameToDisplay,
-} from "@/features/admin/utils";
+} from "@/features/admin/utils/adminUtils";
 import { namesQueryOptions } from "@/features/names/api";
 import { useNameAdminActions } from "@/features/names/hooks/useNameAdminActions";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";

--- a/src/features/admin/utils/adminUtils.test.ts
+++ b/src/features/admin/utils/adminUtils.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { NameWithStats } from "../types";
+import { filterNamesByStatusAndSearch } from "./adminUtils";
+
+describe("filterNamesByStatusAndSearch", () => {
+	const mockNames = [
+		{
+			id: "1",
+			name: "ActiveName1",
+			description: "First active cat",
+			isHidden: false,
+			lockedIn: false,
+		},
+		{
+			id: "2",
+			name: "ActiveName2",
+			description: "Second active feline",
+			isHidden: false,
+			lockedIn: false,
+		},
+		{
+			id: "3",
+			name: "HiddenName",
+			description: "A hidden one",
+			isHidden: true,
+			lockedIn: false,
+		},
+		{
+			id: "4",
+			name: "LockedName",
+			description: "A locked one",
+			isHidden: false,
+			lockedIn: true,
+		},
+		{
+			id: "5",
+			name: "HiddenLockedName",
+			description: "A hidden and locked one",
+			isHidden: true,
+			lockedIn: true,
+		},
+	] as NameWithStats[];
+
+	it("returns all names when filter is 'all' and search is empty", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "all", "");
+		expect(result).toHaveLength(5);
+		expect(result).toEqual(mockNames);
+	});
+
+	it("filters by 'active' status", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "active", "");
+		expect(result).toHaveLength(2);
+		expect(result.map((n) => n.id)).toEqual(["1", "2"]);
+	});
+
+	it("filters by 'hidden' status", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "hidden", "");
+		expect(result).toHaveLength(2);
+		expect(result.map((n) => n.id)).toEqual(["3", "5"]);
+	});
+
+	it("filters by 'locked' status", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "locked", "");
+		expect(result).toHaveLength(2);
+		expect(result.map((n) => n.id)).toEqual(["4", "5"]);
+	});
+
+	it("filters by search term matching name (case-insensitive)", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "all", "activename1");
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("1");
+	});
+
+	it("filters by search term matching description (case-insensitive)", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "all", "feline");
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("2");
+	});
+
+	it("returns empty array when search term has no matches", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "all", "nonexistent");
+		expect(result).toHaveLength(0);
+	});
+
+	it("combines status filter and search term", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "active", "active");
+		expect(result).toHaveLength(2); // Matches "ActiveName1" and "ActiveName2"
+
+		const resultHidden = filterNamesByStatusAndSearch(mockNames, "hidden", "one");
+		expect(resultHidden).toHaveLength(2); // Matches "A hidden one" and "A hidden and locked one"
+
+		const resultLocked = filterNamesByStatusAndSearch(mockNames, "locked", "one");
+		expect(resultLocked).toHaveLength(2); // Matches "A locked one" and "A hidden and locked one"
+
+		// Search term matches a name that is filtered out by status
+		const resultNoMatch = filterNamesByStatusAndSearch(mockNames, "active", "hidden");
+		expect(resultNoMatch).toHaveLength(0);
+	});
+
+	it("ignores whitespace-only search term", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "all", "   ");
+		expect(result).toHaveLength(5);
+	});
+
+	it("trims whitespace from search term", () => {
+		const result = filterNamesByStatusAndSearch(mockNames, "all", "  LockedName  ");
+		expect(result).toHaveLength(2);
+		expect(result.map((n) => n.id)).toEqual(["4", "5"]);
+	});
+});

--- a/src/features/admin/utils/adminUtils.ts
+++ b/src/features/admin/utils/adminUtils.ts
@@ -5,7 +5,7 @@ import {
 	matchesNameSearchTerm,
 } from "@/shared/lib/names/nameFilters";
 import type { NameItem } from "@/shared/types";
-import type { AdminStats, NameFilter, NameWithStats, SiteStatsLike } from "./types";
+import type { AdminStats, NameFilter, NameWithStats, SiteStatsLike } from "../types";
 
 export function toNumber(value: unknown): number {
 	const parsed = Number(value);

--- a/src/shared/components/profile/ProfileInner.test.tsx
+++ b/src/shared/components/profile/ProfileInner.test.tsx
@@ -69,7 +69,7 @@ describe("ProfileInner", () => {
 			expect(onLogin).toHaveBeenCalledWith("Ada");
 		});
 		expect(
-			screen.getByText("We couldn't log you in with that name. Try again."),
+			await screen.findByText("We couldn't log you in with that name. Try again."),
 		).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Begin Journey" })).toBeInTheDocument();
 	});


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the pure function `filterNamesByStatusAndSearch` in `src/features/admin/utils/adminUtils.ts`.
📊 **Coverage:** Tests comprehensively cover 'all', 'active', 'hidden', and 'locked' filters, case-insensitive search by name or description, combinations of status filters and search terms, and handling of blank/whitespace search terms.
✨ **Result:** Improved test coverage and reliability for admin filtering logic. The PR also properly aligns the file structure (`utils.ts` renamed to `utils/adminUtils.ts`) and fixes an unrelated flaky test in `ProfileInner.test.tsx` by waiting for findByText.

---
*PR created automatically by Jules for task [5933129741749682572](https://jules.google.com/task/5933129741749682572) started by @guitarbeat*

## Summary by Sourcery

Add unit tests for the admin filtering utility and stabilize related tests while reorganizing the admin utils file structure.

New Features:
- Introduce unit tests for the admin filtering utility function in the admin utils module.

Bug Fixes:
- Fix a flaky ProfileInner login error test by awaiting the asynchronous error message rendering.

Enhancements:
- Move the generic admin utilities from the top-level admin utils file into a dedicated utils/adminUtils module and update type imports accordingly.

Tests:
- Add comprehensive unit tests for admin name filtering logic, covering status filters and search behavior.