### PR TITLE
feat(nav): replace bottom navigation with dynamic island UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "fuse.js": "^7.3.0",
     "gsap": "^3.15.0",
     "lucide-react": "^0.577.0",
+    "motion": "^12.40.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -3773,6 +3776,20 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-extra@11.1.0:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
     engines: {node: '>=14.14'}
@@ -4222,8 +4239,28 @@ packages:
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
 
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
   motion-utils@12.36.0:
     resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.40.0:
+    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -9518,6 +9555,15 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  framer-motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   fs-extra@11.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -9933,7 +9979,21 @@ snapshots:
     dependencies:
       motion-utils: 12.36.0
 
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
   motion-utils@12.36.0: {}
+
+  motion-utils@12.39.0: {}
+
+  motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      framer-motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   mri@1.2.0: {}
 

--- a/src/shared/components/layout/FloatingNavbar.test.tsx
+++ b/src/shared/components/layout/FloatingNavbar.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { CSSProperties, ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FloatingNavbar } from "./FloatingNavbar";
@@ -45,22 +44,6 @@ const mockStore = {
 	},
 };
 
-vi.mock("./LiquidGlass", () => ({
-	default: ({
-		children,
-		className,
-		style,
-	}: {
-		children: ReactNode;
-		className?: string;
-		style?: CSSProperties;
-	}) => (
-		<div data-testid="liquid-glass" className={className} style={style}>
-			{children}
-		</div>
-	),
-}));
-
 vi.mock("@/store/appStore", () => ({
 	default: () => mockStore,
 }));
@@ -99,6 +82,22 @@ function mountSections(topById: Record<string, number>) {
 	}
 }
 
+function getNav() {
+	return screen.getByRole("navigation", { name: "Primary" });
+}
+
+function expandNav() {
+	fireEvent.click(screen.getByTestId("dynamic-island-shell"));
+}
+
+function setPastHeroScroll() {
+	Object.defineProperty(window, "scrollY", {
+		writable: true,
+		configurable: true,
+		value: 900,
+	});
+}
+
 describe("FloatingNavbar", () => {
 	beforeEach(() => {
 		mockStore.tournament.selectedNames = [];
@@ -120,6 +119,20 @@ describe("FloatingNavbar", () => {
 		Object.defineProperty(window, "scrollTo", {
 			writable: true,
 			value: vi.fn(),
+		});
+		Object.defineProperty(document.documentElement, "scrollHeight", {
+			configurable: true,
+			value: 2000,
+		});
+		Object.defineProperty(window, "innerHeight", {
+			writable: true,
+			configurable: true,
+			value: 800,
+		});
+		Object.defineProperty(window, "scrollY", {
+			writable: true,
+			configurable: true,
+			value: 0,
 		});
 
 		vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
@@ -144,10 +157,16 @@ describe("FloatingNavbar", () => {
 			</QueryClientProvider>,
 		);
 
-	it("renders home navigation items and tracks the active section", () => {
+	it("renders the dynamic island navigation and tracks the active section", () => {
 		mountSections({ pick: 20, tournament: 200, analysis: 400 });
+		setPastHeroScroll();
 
 		renderWithRouter();
+
+		expect(getNav()).toBeInTheDocument();
+		expect(screen.getByTestId("dynamic-island-collapsed-label")).toHaveTextContent("Pick Names");
+
+		expandNav();
 
 		expect(screen.getByRole("button", { name: "Pick Names" })).toHaveAttribute(
 			"aria-current",
@@ -159,31 +178,40 @@ describe("FloatingNavbar", () => {
 
 	it("renders an admin shortcut for admin users", () => {
 		mountSections({ pick: 20, tournament: 200, analysis: 400 });
+		setPastHeroScroll();
 		mockStore.user.isLoggedIn = true;
 		mockStore.user.name = "Avery Admin";
 		mockStore.user.isAdmin = true;
 
 		renderWithRouter();
 
+		expandNav();
+
 		expect(screen.getByRole("button", { name: "Admin" })).toBeInTheDocument();
 	});
 
 	it("promotes the first item to a highlighted start action when enough names are selected", () => {
 		mountSections({ pick: 0, tournament: 200, analysis: 400 });
+		setPastHeroScroll();
 		mockStore.tournament.selectedNames = ["Luna", "Fig", "Miso"];
 
 		renderWithRouter();
 
+		expect(screen.getByTestId("dynamic-island-collapsed-label")).toHaveTextContent("Start (3)");
+
+		expandNav();
+
 		const startButton = screen.getByRole("button", { name: "Start (3)" });
 
 		expect(startButton).toBeInTheDocument();
-		expect(startButton).toHaveClass("floating-navbar__item--accent");
+		expect(startButton).toHaveClass("text-primary");
 		expect(screen.queryByRole("button", { name: "Pick Names" })).not.toBeInTheDocument();
 	});
 
 	it("shows analyze as the current destination on the analysis route", () => {
 		mockStore.tournament.isComplete = true;
 		mockStore.tournament.names = ["Luna", "Fig"];
+		setPastHeroScroll();
 		mountSections({
 			pick: 200,
 			tournament: 200,
@@ -194,6 +222,8 @@ describe("FloatingNavbar", () => {
 
 		renderWithRouter(["/"]);
 
+		expandNav();
+
 		expect(screen.getByRole("button", { name: "Analyze" })).toHaveAttribute(
 			"aria-current",
 			"location",
@@ -202,9 +232,12 @@ describe("FloatingNavbar", () => {
 
 	it("uses pressed semantics for the layout mode chip without treating it as the current destination", () => {
 		mountSections({ pick: 0, tournament: 200, analysis: 400 });
+		setPastHeroScroll();
 		mockStore.ui.isSwipeMode = true;
 
 		renderWithRouter();
+
+		expandNav();
 
 		const modeChip = screen.getByRole("button", { name: "Swipe mode active" });
 
@@ -217,22 +250,28 @@ describe("FloatingNavbar", () => {
 
 	it("renders the logged-in avatar when available", () => {
 		mountSections({ pick: 0, tournament: 200, analysis: 400 });
+		setPastHeroScroll();
 		mockStore.user.isLoggedIn = true;
 		mockStore.user.name = "Avery Admin";
 		mockStore.user.avatarUrl = "https://example.com/avatar.png";
 
 		renderWithRouter();
 
+		expandNav();
+
 		expect(screen.getByAltText("Avery")).toBeInTheDocument();
 	});
 
 	it("keeps the admin profile icon treatment when no avatar is present", () => {
 		mountSections({ pick: 0, suggest: 200, profile: 24 });
+		setPastHeroScroll();
 		mockStore.user.isLoggedIn = true;
 		mockStore.user.name = "Avery Admin";
 		mockStore.user.isAdmin = true;
 
 		renderWithRouter();
+
+		expandNav();
 
 		const profileButton = screen.getByRole("button", { name: "Avery" });
 		const profileIcon = profileButton.querySelector("svg");
@@ -253,6 +292,8 @@ describe("FloatingNavbar", () => {
 		mockStore.user.isAdmin = true;
 
 		renderWithRouter(["/admin"]);
+
+		expandNav();
 
 		expect(screen.getByRole("button", { name: "Admin" })).toHaveAttribute(
 			"aria-current",

--- a/src/shared/components/layout/FloatingNavbar.tsx
+++ b/src/shared/components/layout/FloatingNavbar.tsx
@@ -8,17 +8,18 @@ import {
 	Trophy,
 	User,
 } from "lucide-react";
-import type { ElementType, ReactNode } from "react";
-import { lazy, Suspense, useCallback, useEffect, useId, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/app/providers/Providers";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Modal } from "@/shared/components/layout/Modal";
+import {
+	DynamicIslandNav,
+	type DynamicIslandNavItem,
+} from "@/shared/components/ui/dynamic-island-nav";
 import { hapticNavTap, hapticTournamentStart } from "@/shared/lib/browser/haptics";
 import { cn } from "@/shared/lib/utils";
 import useAppStore from "@/store/appStore";
-import { getGlassPreset } from "./GlassPresets";
-import LiquidGlass from "./LiquidGlass";
 
 type NavSection = "pick" | "tournament" | "analysis";
 
@@ -40,62 +41,6 @@ const LazyNameSuggestion = lazy(() =>
 	})),
 );
 
-function FloatingNavItem({
-	icon: Icon,
-	label,
-	variant = "primary",
-	isCurrent = false,
-	isPressed = false,
-	isAccent = false,
-	hasBadge = false,
-	onClick,
-	customIcon,
-	className,
-	ariaLabel,
-}: {
-	icon: ElementType;
-	label: string;
-	variant?: "primary" | "utility";
-	isCurrent?: boolean;
-	isPressed?: boolean;
-	isAccent?: boolean;
-	hasBadge?: boolean;
-	onClick: () => void;
-	customIcon?: ReactNode;
-	className?: string;
-	ariaLabel?: string;
-}) {
-	return (
-		<button
-			type="button"
-			className={cn(
-				"floating-navbar__item",
-				"motion-safe:duration-200 motion-safe:ease-out active:scale-[0.98]",
-				variant === "utility" ? "floating-navbar__item--utility" : "floating-navbar__item--primary",
-				isAccent && "floating-navbar__item--accent",
-				className,
-			)}
-			onClick={onClick}
-			aria-current={variant === "primary" && isCurrent ? "location" : undefined}
-			aria-pressed={variant === "utility" ? isPressed : undefined}
-			aria-label={ariaLabel ?? label}
-		>
-			<span className="floating-navbar__icon" aria-hidden="true">
-				{customIcon || <Icon className="h-5 w-5 sm:h-6 sm:w-6" />}
-				{hasBadge && <span className="floating-navbar__badge" />}
-			</span>
-			<span
-				className={cn(
-					"floating-navbar__label",
-					variant === "utility" && "floating-navbar__label--utility",
-				)}
-			>
-				{label}
-			</span>
-		</button>
-	);
-}
-
 export function FloatingNavbar() {
 	const appStore = useAppStore();
 	const navigate = useNavigate();
@@ -108,8 +53,8 @@ export function FloatingNavbar() {
 	const { setSwipeMode } = uiActions;
 	const [activeSection, setActiveSection] = useState<NavSection>("pick");
 	const [isNavVisible, setIsNavVisible] = useState(true);
-	const [_isMobile, setIsMobile] = useState(false);
 	const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+	const [scrollProgress, setScrollProgress] = useState(0);
 	const [pendingScroll, setPendingScroll] = useState<NavSection | null>(null);
 	const [isProfileOpen, setIsProfileOpen] = useState(false);
 	const [isSuggestOpen, setIsSuggestOpen] = useState(false);
@@ -127,7 +72,6 @@ export function FloatingNavbar() {
 		width: number;
 		height: number;
 	} | null>(null);
-	const navGlassId = useId();
 
 	const isHomeRoute = location.pathname === "/";
 	const isAdminRoute = location.pathname === "/admin";
@@ -137,7 +81,6 @@ export function FloatingNavbar() {
 	const selectedCount = selectedNames?.length || 0;
 	const isTournamentActive = Boolean(tournament.names);
 	const profileLabel = isLoggedIn ? userName?.split(" ")[0] || "Profile" : "Profile";
-	const primaryItemCount = isAdmin ? 5 : 4;
 
 	const scrollToSection = useCallback(
 		(key: NavSection) => {
@@ -159,7 +102,7 @@ export function FloatingNavbar() {
 		[prefersReducedMotion],
 	);
 
-	const handleStartTournament = () => {
+	const handleStartTournament = useCallback(() => {
 		hapticTournamentStart();
 		if (selectedNames && selectedNames.length >= 2) {
 			tournamentActions.setNames(selectedNames);
@@ -170,24 +113,57 @@ export function FloatingNavbar() {
 				navigate("/");
 			}
 		}
-	};
+	}, [isHomeRoute, navigate, scrollToSection, selectedNames, tournamentActions]);
 
-	const handleNavClick = (key: NavSection) => {
-		hapticNavTap();
-		if (!isHomeRoute) {
-			setPendingScroll(key);
-			navigate("/");
-			return;
-		}
-		scrollToSection(key);
-	};
+	const handleNavClick = useCallback(
+		(key: NavSection) => {
+			hapticNavTap();
+			if (!isHomeRoute) {
+				setPendingScroll(key);
+				navigate("/");
+				return;
+			}
+			scrollToSection(key);
+		},
+		[isHomeRoute, navigate, scrollToSection],
+	);
 
-	const handleAdminClick = () => {
+	const handleAdminClick = useCallback(() => {
 		hapticNavTap();
 		if (!isAdminRoute) {
 			navigate("/admin");
 		}
-	};
+	}, [isAdminRoute, navigate]);
+
+	const openProfileModal = useCallback(() => {
+		hapticNavTap();
+		const buttonEl = profileButtonRef.current;
+		if (buttonEl) {
+			const rect = buttonEl.getBoundingClientRect();
+			setProfileOriginRect({
+				x: rect.left,
+				y: rect.top,
+				width: rect.width,
+				height: rect.height,
+			});
+		}
+		setIsProfileOpen(true);
+	}, []);
+
+	const openSuggestModal = useCallback(() => {
+		hapticNavTap();
+		const buttonEl = suggestButtonRef.current;
+		if (buttonEl) {
+			const rect = buttonEl.getBoundingClientRect();
+			setSuggestOriginRect({
+				x: rect.left,
+				y: rect.top,
+				width: rect.width,
+				height: rect.height,
+			});
+		}
+		setIsSuggestOpen(true);
+	}, []);
 
 	useEffect(() => {
 		if (!isHomeRoute || !pendingScroll) {
@@ -227,6 +203,11 @@ export function FloatingNavbar() {
 					}
 				}
 				setActiveSection(current);
+
+				const total = document.documentElement.scrollHeight - window.innerHeight;
+				setScrollProgress(
+					total > 0 ? Math.min(100, Math.max(0, (window.scrollY / total) * 100)) : 0,
+				);
 			});
 		};
 
@@ -238,6 +219,12 @@ export function FloatingNavbar() {
 				cancelAnimationFrame(rafId);
 			}
 		};
+	}, [isHomeRoute]);
+
+	useEffect(() => {
+		if (!isHomeRoute) {
+			setScrollProgress(0);
+		}
 	}, [isHomeRoute]);
 
 	useEffect(() => {
@@ -268,12 +255,9 @@ export function FloatingNavbar() {
 		let lastScrollY = window.scrollY;
 		let ticking = false;
 		const mobileMediaQuery = window.matchMedia("(max-width: 768px)");
-		let isCurrentlyMobile = mobileMediaQuery.matches;
-
-		setIsMobile(isCurrentlyMobile);
 
 		const onScroll = () => {
-			if (!isCurrentlyMobile) {
+			if (!mobileMediaQuery.matches) {
 				lastScrollY = window.scrollY;
 				return;
 			}
@@ -299,9 +283,7 @@ export function FloatingNavbar() {
 		};
 
 		const onViewportChange = () => {
-			isCurrentlyMobile = mobileMediaQuery.matches;
-			setIsMobile(isCurrentlyMobile);
-			if (!isCurrentlyMobile) {
+			if (!mobileMediaQuery.matches) {
 				setIsNavVisible(true);
 			}
 		};
@@ -315,6 +297,153 @@ export function FloatingNavbar() {
 		};
 	}, []);
 
+	const primaryLabel = useMemo(() => {
+		if (isAdminRoute) {
+			return "Admin";
+		}
+		if (!isHomeRoute) {
+			return "Navigation";
+		}
+		if (isTournamentActive) {
+			return "Tournament";
+		}
+		if (selectedCount >= 2) {
+			return `Start (${selectedCount})`;
+		}
+		if (activeSection === "analysis") {
+			return "Analyze";
+		}
+		if (activeSection === "tournament") {
+			return "Bracket";
+		}
+		return "Pick Names";
+	}, [activeSection, isAdminRoute, isHomeRoute, isTournamentActive, selectedCount]);
+
+	const navItems = useMemo((): DynamicIslandNavItem[] => {
+		const items: DynamicIslandNavItem[] = [];
+
+		if (isHomeRoute) {
+			items.push({
+				id: "pick",
+				label: isTournamentActive
+					? "Tournament"
+					: selectedCount >= 2
+						? `Start (${selectedCount})`
+						: "Pick Names",
+				level: 1,
+				icon: isTournamentActive ? (
+					<Trophy className="h-4 w-4" />
+				) : selectedCount >= 2 ? (
+					<Trophy className="h-4 w-4" />
+				) : (
+					<CheckCircle className="h-4 w-4" />
+				),
+				isActive: activeSection === "pick" || activeSection === "tournament",
+				isAccent: isTournamentActive || selectedCount >= 2,
+				onClick: () => {
+					if (isTournamentActive) {
+						handleNavClick("tournament");
+					} else if (selectedCount >= 2) {
+						handleStartTournament();
+					} else {
+						handleNavClick("pick");
+					}
+				},
+			});
+
+			items.push({
+				id: "analysis",
+				label: "Analyze",
+				level: 1,
+				icon: <BarChart3 className="h-4 w-4" />,
+				isActive: activeSection === "analysis",
+				hasBadge: Object.keys(tournament.ratings).length > 0 && activeSection !== "analysis",
+				onClick: () => handleNavClick("analysis"),
+			});
+		}
+
+		items.push({
+			id: "suggest",
+			label: "Suggest",
+			level: isHomeRoute ? 1 : 1,
+			icon: <Lightbulb className="h-4 w-4" />,
+			isActive: isSuggestOpen,
+			onClick: openSuggestModal,
+		});
+
+		if (isAdmin) {
+			items.push({
+				id: "admin",
+				label: "Admin",
+				level: 1,
+				icon: <Lock className="h-4 w-4" />,
+				isActive: isAdminRoute,
+				onClick: handleAdminClick,
+			});
+		}
+
+		items.push({
+			id: "profile",
+			label: profileLabel,
+			level: 1,
+			icon:
+				isLoggedIn && avatarUrl ? (
+					<img
+						src={avatarUrl}
+						alt={profileLabel}
+						className="h-5 w-5 rounded-full border border-foreground/15 object-cover"
+					/>
+				) : (
+					<User
+						className={cn(
+							"h-4 w-4",
+							isLoggedIn && isAdmin && "text-chart-4",
+							isLoggedIn && !isAdmin && "text-primary",
+						)}
+					/>
+				),
+			isActive: isProfileOpen,
+			onClick: openProfileModal,
+		});
+
+		if (isHomeRoute) {
+			items.push({
+				id: "layout-mode",
+				label: isSwipeMode ? "Swipe mode" : "Grid mode",
+				level: 2,
+				icon: isSwipeMode ? <Layers className="h-4 w-4" /> : <LayoutGrid className="h-4 w-4" />,
+				ariaLabel: isSwipeMode ? "Swipe mode active" : "Grid mode active",
+				ariaPressed: isSwipeMode,
+				onClick: () => {
+					hapticNavTap();
+					setSwipeMode(!isSwipeMode);
+				},
+			});
+		}
+
+		return items;
+	}, [
+		activeSection,
+		avatarUrl,
+		handleAdminClick,
+		handleNavClick,
+		handleStartTournament,
+		isAdmin,
+		isAdminRoute,
+		isHomeRoute,
+		isLoggedIn,
+		isProfileOpen,
+		isSuggestOpen,
+		isSwipeMode,
+		isTournamentActive,
+		openProfileModal,
+		openSuggestModal,
+		profileLabel,
+		selectedCount,
+		setSwipeMode,
+		tournament.ratings,
+	]);
+
 	if (isTournamentRoute) {
 		return null;
 	}
@@ -323,144 +452,24 @@ export function FloatingNavbar() {
 
 	return (
 		<>
-			<div
-				className={cn(
-					"floating-navbar-frame",
-					!prefersReducedMotion && "transition-transform transition-opacity duration-300 ease-out",
-					prefersReducedMotion && "transition-none",
-					shouldShow
-						? "translate-y-0 opacity-100"
-						: "translate-y-[calc(100%+1.25rem)] opacity-0 pointer-events-none",
-				)}
-			>
-				<LiquidGlass
-					id={`floating-navbar-${navGlassId.replace(/:/g, "-")}`}
-					{...getGlassPreset("navbar")}
-					className="floating-navbar-shell app-navbar-glass"
-					style={{ width: "100%", height: "auto" }}
-				>
-					<nav aria-label="Primary" className="floating-navbar">
-						<div
-							className="floating-navbar__primary"
-							style={{
-								gridTemplateColumns: `repeat(${primaryItemCount}, minmax(0, 1fr))`,
-							}}
-						>
-							<FloatingNavItem
-								icon={isTournamentActive ? Trophy : selectedCount >= 2 ? Trophy : CheckCircle}
-								label={
-									isTournamentActive
-										? "Tournament"
-										: selectedCount >= 2
-											? `Start (${selectedCount})`
-											: "Pick Names"
-								}
-								isCurrent={
-									isHomeRoute && (activeSection === "pick" || activeSection === "tournament")
-								}
-								isAccent={isTournamentActive || selectedCount >= 2}
-								onClick={() => {
-									if (isTournamentActive) {
-										handleNavClick("tournament");
-									} else if (selectedCount >= 2) {
-										handleStartTournament();
-									} else {
-										handleNavClick("pick");
-									}
-								}}
-							/>
+			<div ref={profileButtonRef} className="sr-only" aria-hidden="true" />
+			<div ref={suggestButtonRef} className="sr-only" aria-hidden="true" />
 
-							<FloatingNavItem
-								icon={BarChart3}
-								label="Analyze"
-								isCurrent={isHomeRoute && activeSection === "analysis"}
-								hasBadge={
-									Object.keys(tournament.ratings).length > 0 && activeSection !== "analysis"
-								}
-								onClick={() => handleNavClick("analysis")}
-							/>
+			<DynamicIslandNav
+				items={navItems}
+				collapsedLabel={primaryLabel}
+				collapsedLabelKey={
+					isAdminRoute
+						? "admin"
+						: isHomeRoute
+							? `${activeSection}-${selectedCount}-${isTournamentActive}`
+							: "away"
+				}
+				progress={scrollProgress}
+				isVisible={shouldShow}
+				prefersReducedMotion={prefersReducedMotion}
+			/>
 
-							<div ref={suggestButtonRef} className="contents">
-								<FloatingNavItem
-									icon={Lightbulb}
-									label="Suggest"
-									isCurrent={isSuggestOpen}
-									onClick={() => {
-										hapticNavTap();
-										const buttonEl = suggestButtonRef.current?.querySelector("button");
-										if (buttonEl) {
-											const rect = buttonEl.getBoundingClientRect();
-											setSuggestOriginRect({
-												x: rect.left,
-												y: rect.top,
-												width: rect.width,
-												height: rect.height,
-											});
-										}
-										setIsSuggestOpen(true);
-									}}
-								/>
-							</div>
-
-							{isAdmin && (
-								<FloatingNavItem
-									icon={Lock}
-									label="Admin"
-									isCurrent={isAdminRoute}
-									onClick={handleAdminClick}
-								/>
-							)}
-
-							<div ref={profileButtonRef} className="contents">
-								<FloatingNavItem
-									icon={User}
-									label={profileLabel}
-									isCurrent={isProfileOpen}
-									onClick={() => {
-										hapticNavTap();
-										const buttonEl = profileButtonRef.current?.querySelector("button");
-										if (buttonEl) {
-											const rect = buttonEl.getBoundingClientRect();
-											setProfileOriginRect({
-												x: rect.left,
-												y: rect.top,
-												width: rect.width,
-												height: rect.height,
-											});
-										}
-										setIsProfileOpen(true);
-									}}
-									customIcon={
-										isLoggedIn && avatarUrl ? (
-											<img src={avatarUrl} alt={profileLabel} className="floating-navbar__avatar" />
-										) : (
-											<User
-												className={cn(
-													"h-5 w-5",
-													isLoggedIn && isAdmin && "text-chart-4",
-													isLoggedIn && !isAdmin && "text-primary",
-												)}
-											/>
-										)
-									}
-								/>
-							</div>
-						</div>
-
-						{/* Utility toggle hidden on mobile via CSS, moved into picker surface */}
-						<div className="floating-navbar__utility">
-							<FloatingNavItem
-								icon={isSwipeMode ? Layers : LayoutGrid}
-								label={isSwipeMode ? "Swipe" : "Grid"}
-								variant="utility"
-								isPressed={isSwipeMode}
-								ariaLabel={isSwipeMode ? "Swipe mode active" : "Grid mode active"}
-								onClick={() => setSwipeMode(!isSwipeMode)}
-							/>
-						</div>
-					</nav>
-				</LiquidGlass>
-			</div>
 			{isProfileOpen && (
 				<Modal
 					title="Your Profile"

--- a/src/shared/components/ui/dynamic-island-nav.tsx
+++ b/src/shared/components/ui/dynamic-island-nav.tsx
@@ -1,0 +1,276 @@
+import { X } from "lucide-react";
+import { AnimatePresence, motion, type Transition } from "motion/react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { cn } from "@/shared/lib/utils";
+
+const islandTransition: Transition = {
+	type: "tween",
+	ease: [0.22, 1, 0.36, 1],
+	duration: 0.5,
+};
+
+function CircleProgress({ percentage }: { percentage: number }) {
+	const size = 24;
+	const strokeWidth = 2.5;
+	const radius = (size - strokeWidth) / 2;
+	const circumference = 2 * Math.PI * radius;
+	const offset = circumference - (percentage / 100) * circumference;
+
+	return (
+		<svg width={size} height={size} className="-rotate-90 shrink-0" aria-hidden="true">
+			<circle
+				cx={size / 2}
+				cy={size / 2}
+				r={radius}
+				fill="none"
+				stroke="var(--muted)"
+				strokeWidth={strokeWidth}
+			/>
+			<motion.circle
+				cx={size / 2}
+				cy={size / 2}
+				r={radius}
+				fill="none"
+				stroke="var(--foreground)"
+				strokeWidth={strokeWidth}
+				strokeDasharray={circumference}
+				initial={{ strokeDashoffset: circumference }}
+				animate={{ strokeDashoffset: offset }}
+				transition={{ duration: 0.15, ease: "easeOut" }}
+				strokeLinecap="round"
+			/>
+		</svg>
+	);
+}
+
+export type DynamicIslandNavItem = {
+	id: string;
+	label: string;
+	level?: number;
+	icon?: ReactNode;
+	isActive?: boolean;
+	isAccent?: boolean;
+	hasBadge?: boolean;
+	ariaLabel?: string;
+	ariaPressed?: boolean;
+	onClick: () => void;
+};
+
+type DynamicIslandNavProps = {
+	items: DynamicIslandNavItem[];
+	/** Label shown in the collapsed pill */
+	collapsedLabel: string;
+	/** Key used to animate label changes in the collapsed pill */
+	collapsedLabelKey?: string;
+	progress?: number;
+	isVisible?: boolean;
+	prefersReducedMotion?: boolean;
+	expandedTitle?: string;
+};
+
+export function DynamicIslandNav({
+	items,
+	collapsedLabel,
+	collapsedLabelKey,
+	progress = 0,
+	isVisible = true,
+	prefersReducedMotion = false,
+	expandedTitle = "NAVIGATION",
+}: DynamicIslandNavProps) {
+	const [hoveredId, setHoveredId] = useState<string | null>(null);
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	const minLevel = useMemo(() => {
+		if (items.length === 0) {
+			return 1;
+		}
+		return Math.min(...items.map((item) => item.level ?? 1));
+	}, [items]);
+
+	const expandedHeight = Math.min(420, Math.max(220, 72 + items.length * 44));
+
+	useEffect(() => {
+		if (!isExpanded) {
+			return;
+		}
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				setIsExpanded(false);
+			}
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [isExpanded]);
+
+	return (
+		<>
+			<AnimatePresence>
+				{isExpanded && (
+					<motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={islandTransition}
+						className="fixed inset-0 z-[9998] bg-black/20 backdrop-blur-[4px]"
+						onClick={() => setIsExpanded(false)}
+						aria-hidden="true"
+					/>
+				)}
+			</AnimatePresence>
+
+			<motion.nav
+				aria-label="Primary"
+				initial={prefersReducedMotion ? false : { y: 50, opacity: 0 }}
+				animate={{
+					y: isVisible ? 0 : 80,
+					opacity: isVisible ? 1 : 0,
+				}}
+				transition={
+					prefersReducedMotion ? { duration: 0 } : { type: "spring", stiffness: 300, damping: 25 }
+				}
+				className={cn(
+					"fixed bottom-[max(1.25rem,var(--app-nav-bottom-offset,1.25rem))] left-1/2 z-[9999] flex -translate-x-1/2 flex-col items-center",
+					!isVisible && "pointer-events-none",
+				)}
+			>
+				<motion.div
+					data-testid="dynamic-island-shell"
+					onClick={() => {
+						if (!isExpanded) {
+							setIsExpanded(true);
+						}
+					}}
+					initial={false}
+					animate={{
+						width: isExpanded ? 340 : 280,
+						height: isExpanded ? expandedHeight : 52,
+						borderRadius: isExpanded ? 24 : 26,
+					}}
+					transition={islandTransition}
+					style={{ cursor: isExpanded ? "default" : "pointer" }}
+					className="relative overflow-hidden border border-foreground/10 bg-background/95 text-foreground shadow-2xl backdrop-blur-md"
+				>
+					<motion.div
+						initial={false}
+						animate={{
+							opacity: isExpanded ? 0 : 1,
+							scale: isExpanded ? 0.95 : 1,
+							filter: isExpanded ? "blur(4px)" : "blur(0px)",
+						}}
+						transition={{ ...islandTransition, delay: isExpanded ? 0 : 0.1 }}
+						className={cn(
+							"absolute inset-0 flex items-center gap-3 px-4 sm:px-5",
+							isExpanded && "pointer-events-none",
+						)}
+					>
+						<div className="h-2 w-2 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+
+						<div className="relative flex h-full flex-1 items-center overflow-hidden text-left">
+							<AnimatePresence mode="popLayout" initial={false}>
+								<motion.span
+									data-testid="dynamic-island-collapsed-label"
+									key={collapsedLabelKey ?? collapsedLabel}
+									initial={prefersReducedMotion ? false : { opacity: 0, y: 15 }}
+									animate={{ opacity: 1, y: 0 }}
+									exit={prefersReducedMotion ? undefined : { opacity: 0, y: -15 }}
+									transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+									className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-foreground"
+								>
+									{collapsedLabel}
+								</motion.span>
+							</AnimatePresence>
+						</div>
+
+						<CircleProgress percentage={progress} />
+					</motion.div>
+
+					<motion.div
+						initial={false}
+						animate={{
+							opacity: isExpanded ? 1 : 0,
+							scale: isExpanded ? 1 : 1.05,
+						}}
+						transition={{ ...islandTransition, delay: isExpanded ? 0.1 : 0 }}
+						className={cn("absolute inset-0 flex flex-col", !isExpanded && "pointer-events-none")}
+					>
+						<div className="flex shrink-0 items-center justify-between px-6 pb-3 pt-5">
+							<span className="text-[11px] font-semibold tracking-[0.08em] text-muted-foreground">
+								{expandedTitle}
+							</span>
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									setIsExpanded(false);
+								}}
+								className="text-muted-foreground transition-colors hover:text-foreground"
+								aria-label="Close navigation menu"
+							>
+								<X className="h-5 w-5" />
+							</button>
+						</div>
+
+						<div className="flex-1 overflow-y-auto overscroll-contain px-3 pb-4">
+							<div className="flex flex-col gap-0.5">
+								{items.map((item) => {
+									const isActive = Boolean(item.isActive);
+									const isHovered = hoveredId === item.id;
+									const indentLevel = Math.max(0, (item.level ?? 1) - minLevel);
+									const paddingLeft = indentLevel * 14 + 12;
+
+									return (
+										<button
+											type="button"
+											key={item.id}
+											aria-label={item.ariaLabel ?? item.label}
+											aria-current={isActive ? "location" : undefined}
+											aria-pressed={
+												typeof item.ariaPressed === "boolean" ? item.ariaPressed : undefined
+											}
+											onMouseEnter={() => setHoveredId(item.id)}
+											onMouseLeave={() => setHoveredId(null)}
+											onClick={(e) => {
+												e.stopPropagation();
+												item.onClick();
+												setIsExpanded(false);
+											}}
+											style={{ paddingLeft: `${paddingLeft}px` }}
+											className={cn(
+												"group flex w-full shrink-0 cursor-pointer items-center gap-2 rounded-lg border-none py-2 pr-3 text-left text-sm transition-all duration-300 ease-out",
+												item.isAccent && !isActive && "text-primary",
+												item.isAccent && isActive && "bg-primary/15 font-medium text-primary",
+												!item.isAccent &&
+													isActive &&
+													"bg-foreground/10 font-medium text-foreground",
+												!isActive && isHovered && "bg-foreground/5 text-foreground/85",
+												!isActive && !isHovered && "bg-transparent text-foreground/45",
+											)}
+										>
+											{item.icon ? (
+												<span className="relative flex shrink-0 items-center justify-center text-foreground/70">
+													{item.icon}
+													{item.hasBadge && (
+														<span className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-primary" />
+													)}
+												</span>
+											) : null}
+											<span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap transition-transform duration-300 group-hover:translate-x-1">
+												{item.label}
+											</span>
+											<motion.div
+												initial={false}
+												animate={{ scale: isActive ? 1 : 0, opacity: isActive ? 1 : 0 }}
+												transition={{ duration: 0.3, ease: "easeOut" }}
+												className="ml-1 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground"
+											/>
+										</button>
+									);
+								})}
+							</div>
+						</div>
+					</motion.div>
+				</motion.div>
+			</motion.nav>
+		</>
+	);
+}

--- a/src/shared/components/ui/dynamic-island-toc.tsx
+++ b/src/shared/components/ui/dynamic-island-toc.tsx
@@ -1,0 +1,325 @@
+import { X } from "lucide-react";
+import { AnimatePresence, motion, type Transition } from "motion/react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { cn } from "@/shared/lib/utils";
+
+// --- Types ---
+
+type HeadingData = {
+	id: string;
+	text: string;
+	level: number;
+	element: HTMLElement;
+};
+
+// --- Shared Animation Configs ---
+
+const islandTransition: Transition = {
+	type: "tween",
+	ease: [0.22, 1, 0.36, 1],
+	duration: 0.5,
+};
+
+// --- Progress Circle Component ---
+
+function CircleProgress({ percentage }: { percentage: number }) {
+	const size = 24;
+	const strokeWidth = 2.5;
+	const radius = (size - strokeWidth) / 2;
+	const circumference = 2 * Math.PI * radius;
+	const offset = circumference - (percentage / 100) * circumference;
+
+	return (
+		<svg width={size} height={size} className="-rotate-90 shrink-0">
+			<circle
+				cx={size / 2}
+				cy={size / 2}
+				r={radius}
+				fill="none"
+				stroke="var(--muted)"
+				strokeWidth={strokeWidth}
+			/>
+			<motion.circle
+				cx={size / 2}
+				cy={size / 2}
+				r={radius}
+				fill="none"
+				stroke="var(--foreground)"
+				strokeWidth={strokeWidth}
+				strokeDasharray={circumference}
+				initial={{ strokeDashoffset: circumference }}
+				animate={{ strokeDashoffset: offset }}
+				transition={{ duration: 0.15, ease: "easeOut" }}
+				strokeLinecap="round"
+			/>
+		</svg>
+	);
+}
+
+// --- Main Component ---
+
+type DynamicIslandTOCProps = {
+	children?: ReactNode;
+	/**
+	 * CSS selector to find headings.
+	 * Defaults to common blog content wrappers and explicit [data-toc] elements.
+	 */
+	selector?: string;
+};
+
+export function DynamicIslandTOC({
+	children,
+	selector = "article h1, article h2, article h3, article h4, .prose h1, .prose h2, .prose h3, .prose h4, [data-toc]",
+}: DynamicIslandTOCProps) {
+	const [headings, setHeadings] = useState<HeadingData[]>([]);
+	const [activeId, setActiveId] = useState<string | null>(null);
+	const [hoveredId, setHoveredId] = useState<string | null>(null);
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [progress, setProgress] = useState(0);
+
+	// 1. DOM Scanning Strategy
+	useEffect(() => {
+		const getHeadings = () => {
+			const elements = Array.from(document.querySelectorAll(selector)) as HTMLElement[];
+
+			const validHeadings = elements
+				.filter((el) => !el.hasAttribute("data-toc-ignore")) // Allow explicit skipping
+				.map((el, index) => {
+					// Auto-generate ID if missing (common in generic Markdown/CMS output)
+					if (!el.id) {
+						const generatedId =
+							el.textContent
+								?.toLowerCase()
+								.replace(/\s+/g, "-")
+								.replace(/[^\w-]/g, "") || `toc-heading-${index}`;
+						el.id = generatedId;
+					}
+
+					// 1. Check data-toc-depth attribute
+					// 2. Fallback to standard HTML tag levels (H1 = 1, H2 = 2)
+					// 3. Default to level 2 if not a heading tag
+					const depthAttr = el.getAttribute("data-toc-depth");
+					let level = 2;
+
+					if (depthAttr) {
+						level = Number.parseInt(depthAttr, 10);
+					} else {
+						const tagName = el.tagName.toUpperCase();
+						if (tagName.startsWith("H") && tagName.length === 2) {
+							level = Number.parseInt(tagName[1], 10);
+						}
+					}
+
+					// Allow title overrides via data-toc-title
+					const text = el.getAttribute("data-toc-title") || el.textContent || "Section";
+
+					return { id: el.id, text, level, element: el };
+				});
+
+			// Sort by DOM order mathematically
+			validHeadings.sort((a, b) =>
+				a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
+			);
+
+			setHeadings(validHeadings);
+		};
+
+		// Slight delay ensures CMS/Markdown hydration is complete
+		const timer = setTimeout(getHeadings, 100);
+		return () => clearTimeout(timer);
+	}, [selector]);
+
+	// 2. Scroll Spy & Progress
+	useEffect(() => {
+		const handleScroll = () => {
+			let currentActiveId: string | null = null;
+			for (const heading of headings) {
+				const top = heading.element.getBoundingClientRect().top;
+				// 120px offset to trigger active state just as heading reaches the top
+				if (top <= 120) {
+					currentActiveId = heading.id;
+				} else {
+					break;
+				}
+			}
+
+			if (!currentActiveId && headings.length > 0) {
+				currentActiveId = headings[0].id;
+			}
+
+			setActiveId(currentActiveId);
+
+			const total = document.documentElement.scrollHeight - window.innerHeight;
+			setProgress(total > 0 ? Math.min(100, Math.max(0, (window.scrollY / total) * 100)) : 0);
+		};
+
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		handleScroll();
+
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, [headings]);
+
+	const activeHeading = headings.find((h) => h.id === activeId);
+
+	// Normalize depths so the highest-level heading in the doc touches the left edge
+	const minLevel = useMemo(() => {
+		if (headings.length === 0) {
+			return 1;
+		}
+		return Math.min(...headings.map((h) => h.level));
+	}, [headings]);
+
+	return (
+		<>
+			{children}
+
+			{/* Backdrop Blur Overlay */}
+			<AnimatePresence>
+				{isExpanded && (
+					<motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={islandTransition}
+						className="fixed inset-0 z-[9998] bg-black/20 backdrop-blur-[4px]"
+						onClick={() => setIsExpanded(false)}
+					/>
+				)}
+			</AnimatePresence>
+
+			{/* Dynamic Island Wrapper */}
+			<motion.div
+				initial={{ y: 50, opacity: 0 }}
+				animate={{ y: 0, opacity: 1 }}
+				transition={{ type: "spring", stiffness: 300, damping: 25 }}
+				className="fixed bottom-[30px] left-1/2 z-[9999] flex -translate-x-1/2 flex-col items-center"
+			>
+				<motion.div
+					onClick={() => {
+						if (!isExpanded) {
+							setIsExpanded(true);
+						}
+					}}
+					initial={false}
+					animate={{
+						width: isExpanded ? 340 : 280,
+						height: isExpanded ? 400 : 52,
+						borderRadius: isExpanded ? 24 : 26,
+					}}
+					transition={islandTransition}
+					style={{ cursor: isExpanded ? "default" : "pointer" }}
+					className="relative overflow-hidden border border-foreground/10 bg-background text-foreground shadow-2xl"
+				>
+					{/* CLOSED PILL CONTENT */}
+					<motion.div
+						initial={false}
+						animate={{
+							opacity: isExpanded ? 0 : 1,
+							scale: isExpanded ? 0.95 : 1,
+							filter: isExpanded ? "blur(4px)" : "blur(0px)",
+						}}
+						transition={{ ...islandTransition, delay: isExpanded ? 0 : 0.1 }}
+						className={cn(
+							"absolute inset-0 flex items-center gap-4 px-4 sm:px-5",
+							isExpanded && "pointer-events-none",
+						)}
+					>
+						<div className="h-2 w-2 shrink-0 rounded-full bg-foreground" />
+
+						<div className="relative flex h-full flex-1 items-center overflow-hidden text-left">
+							<AnimatePresence mode="popLayout" initial={false}>
+								<motion.span
+									key={activeId || "empty"}
+									initial={{ opacity: 0, y: 15 }}
+									animate={{ opacity: 1, y: 0 }}
+									exit={{ opacity: 0, y: -15 }}
+									transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+									className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-foreground"
+								>
+									{activeHeading?.text || "Contents"}
+								</motion.span>
+							</AnimatePresence>
+						</div>
+
+						<CircleProgress percentage={progress} />
+					</motion.div>
+
+					{/* EXPANDED MENU CONTENT */}
+					<motion.div
+						initial={false}
+						animate={{
+							opacity: isExpanded ? 1 : 0,
+							scale: isExpanded ? 1 : 1.05,
+						}}
+						transition={{ ...islandTransition, delay: isExpanded ? 0.1 : 0 }}
+						className={cn("absolute inset-0 flex flex-col", !isExpanded && "pointer-events-none")}
+					>
+						<div className="flex shrink-0 items-center justify-between px-6 pb-3 pt-5">
+							<span className="text-[11px] font-semibold tracking-[0.08em] text-muted-foreground">
+								TABLE OF CONTENTS
+							</span>
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									setIsExpanded(false);
+								}}
+								className="text-muted-foreground transition-colors hover:text-foreground"
+							>
+								<X className="h-5 w-5" />
+							</button>
+						</div>
+
+						<div className="flex-1 overflow-y-auto overscroll-contain px-3 pb-4">
+							<div className="flex flex-col gap-0.5">
+								{headings.map((h) => {
+									const isActive = activeId === h.id;
+									const isHovered = hoveredId === h.id;
+
+									// Dynamically calculate padding based on nesting depth!
+									const indentLevel = Math.max(0, h.level - minLevel);
+									const paddingLeft = indentLevel * 14 + 12; // 12px base + 14px per depth
+
+									return (
+										<button
+											type="button"
+											key={h.id}
+											onMouseEnter={() => setHoveredId(h.id)}
+											onMouseLeave={() => setHoveredId(null)}
+											onClick={(e) => {
+												e.stopPropagation();
+												// Adjust scroll to give fixed headers breathing room
+												const yOffset = -80;
+												const y = h.element.getBoundingClientRect().top + window.scrollY + yOffset;
+												window.scrollTo({ top: y, behavior: "smooth" });
+												setIsExpanded(false);
+											}}
+											style={{ paddingLeft: `${paddingLeft}px` }}
+											className={cn(
+												"group flex w-full shrink-0 cursor-pointer items-center rounded-lg border-none py-2 pr-3 text-left text-sm transition-all duration-300 ease-out",
+												isActive && "bg-foreground/10 font-medium text-foreground",
+												!isActive && isHovered && "bg-foreground/5 text-foreground/85",
+												!isActive && !isHovered && "bg-transparent text-foreground/45",
+											)}
+										>
+											<span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap transition-transform duration-300 group-hover:translate-x-1">
+												{h.text}
+											</span>
+
+											<motion.div
+												initial={false}
+												animate={{ scale: isActive ? 1 : 0, opacity: isActive ? 1 : 0 }}
+												transition={{ duration: 0.3, ease: "easeOut" }}
+												className="ml-3 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground"
+											/>
+										</button>
+									);
+								})}
+							</div>
+						</div>
+					</motion.div>
+				</motion.div>
+			</motion.div>
+		</>
+	);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaces the floating liquid-glass bottom bar with a Dynamic Island–style navigation inspired by the 21st.dev component.
- Collapsed pill shows the active destination plus scroll progress; tap to expand the full menu.
- Preserves scroll spy, section navigation, tournament start CTA, Suggest/Profile modals, admin shortcut, and mobile hide-on-scroll.

## Scope

- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level

- [ ] Low (refactor/docs/tests)
- [x] Medium (feature logic change)
- [ ] High (auth/data/security/infra)

## Validation

- [x] `pnpm run lint`
- [ ] `pnpm run build`
- [x] Tests added/updated for behavior changes
- [x] Manual QA steps documented below

### Automated

- `pnpm run lint` — pass
- `pnpm run lint:types` — pass
- `pnpm exec vitest --run src/shared/components/layout/FloatingNavbar.test.tsx` — pass

## Manual QA

1. Run `pnpm dev` and open `/`.
2. Scroll past the hero; confirm the bottom island pill appears.
3. Tap the pill; confirm the expanded menu lists Pick/Analyze/Suggest/Profile (and Admin when applicable).
4. Select 2+ names; confirm the pill label becomes `Start (N)` and starting the tournament still works.
5. On mobile width, scroll down/up and confirm the island hides/shows with scroll direction.

## Rollout + Revert Plan

- Rollout approach: merge and deploy via normal Vercel preview → production flow.
- Revert command/path: revert PR #958 or restore `FloatingNavbar.tsx` / remove `dynamic-island-nav.tsx` usage.

## Related

- Issue/Task: Cloud agent request — dynamic island nav from 21st.dev
- Follow-up: optional cleanup of unused `navbar.css` if no longer referenced elsewhere
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c993ac3-1f20-4c1c-b17a-00a470747d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c993ac3-1f20-4c1c-b17a-00a470747d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

