### PR TITLE
Unify theme palette and semantic surfaces across the app

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
   <meta name="description"
     content="Pick the perfect cat name via a fun tournament. Save, compare, and share results." />
   <meta name="color-scheme" content="light dark" />
-  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f4f7fb" />
-  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#020617" />
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f2f3f5" />
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0a0e14" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Name Nosferatu" />
@@ -59,11 +59,11 @@
   <!-- * Optimize painting performance with no-visible-paint directive -->
   <style>
     html {
-      background-color: #050b16;
+      background-color: #0a0e14;
     }
 
     body {
-      background-color: #050b16;
+      background-color: #0a0e14;
     }
 
     #deployment-error-display {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,8 +4,8 @@
 	"description": "Pick the perfect cat name via a fun tournament. Save, compare, and share results.",
 	"start_url": "/",
 	"display": "standalone",
-	"background_color": "#050b16",
-	"theme_color": "#020617",
+	"background_color": "#0a0e14",
+	"theme_color": "#0a0e14",
 	"orientation": "portrait-primary",
 	"icons": [
 		{

--- a/src/app/components/AppBootScreen.tsx
+++ b/src/app/components/AppBootScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { SpinnerCircle } from "@/shared/components/layout/Feedback/Loading";
+import { themeText } from "@/shared/lib/themeClasses";
 import useAppStore from "@/store/appStore";
 
 const LOADING_PREVIEW = "/assets/images/loading-preview.png";
@@ -43,7 +44,7 @@ export function AppBootScreen({
 
 	return (
 		<div
-			className="fixed inset-0 z-[10000] flex items-center justify-center overflow-hidden bg-[#080c12] px-6"
+			className="fixed inset-0 z-[10000] flex items-center justify-center overflow-hidden bg-[var(--app-boot-bg)] px-6"
 			role="status"
 			aria-label="Loading application"
 		>
@@ -52,8 +53,8 @@ export function AppBootScreen({
 				aria-hidden="true"
 				style={{
 					background: `
-                                                radial-gradient(ellipse 70% 50% at 20% 15%, hsl(190 55% 18% / 0.28) 0%, transparent 60%),
-                                                radial-gradient(ellipse 55% 45% at 85% 80%, hsl(16 71% 22% / 0.18) 0%, transparent 55%)
+						radial-gradient(ellipse 70% 50% at 20% 15%, hsl(var(--pw-sage-hsl) / 0.22) 0%, transparent 60%),
+						radial-gradient(ellipse 55% 45% at 85% 80%, hsl(var(--pw-coral-hsl) / 0.16) 0%, transparent 55%)
                                         `,
 				}}
 			/>
@@ -65,14 +66,12 @@ export function AppBootScreen({
 					className="mb-8 w-full max-w-[22rem] select-none object-contain"
 				/>
 
-				<p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-white/40">
-					My cat's name is
-				</p>
+				<p className={`${themeText.eyebrowWide} tracking-[0.32em]`}>My cat's name is</p>
 
-				<div className="my-4 h-px w-12 bg-gradient-to-r from-transparent via-white/28 to-transparent" />
+				<div className="my-4 h-px w-12 bg-gradient-to-r from-transparent via-primary/35 to-transparent" />
 
 				<p
-					className="font-display font-black uppercase text-white"
+					className={`font-display ${themeText.heroDisplay}`}
 					style={{
 						fontSize: "clamp(2.618rem, 9vw, 5.5rem)",
 						lineHeight: 0.88,
@@ -88,7 +87,7 @@ export function AppBootScreen({
 
 				<div className="mt-12 flex flex-col items-center gap-3">
 					<SpinnerCircle size="small" />
-					<p className="text-[10px] font-semibold uppercase tracking-[0.26em] text-white/35">
+					<p className={`${themeText.eyebrow} tracking-[0.26em]`}>
 						{message}
 					</p>
 				</div>

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -4,6 +4,7 @@ import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
 import { CinematicHero } from "@/shared/components/ui/CinematicHero";
+import { themeText } from "@/shared/lib/themeClasses";
 import type { NameItem, RatingData } from "@/shared/types";
 
 type HomeHeroState = "loading" | "ready" | "error";
@@ -31,7 +32,7 @@ interface TournamentBracketSectionProps {
 
 function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNames: NameItem[] }) {
 	if (state === "loading") {
-		return <span className="text-white/20">________</span>;
+		return <span className={themeText.heroPlaceholder}>________</span>;
 	}
 	if (state === "error" || lockedNames.length === 0) {
 		return <span>Nosferatu</span>;
@@ -73,12 +74,10 @@ export function HomeHeroSection({
 		<section className="relative isolate flex min-h-[100dvh] flex-col items-center justify-center px-6 text-center">
 			<div aria-hidden="true" className="flex-[0.55]" />
 
-			<p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.28em] text-white/40">
-				My cat's name is
-			</p>
+			<p className={`mb-4 ${themeText.eyebrowWide}`}>My cat's name is</p>
 
 			<h1
-				className="font-black uppercase leading-[0.88] tracking-tighter text-white"
+				className={themeText.heroDisplay}
 				style={{ fontSize: "clamp(2rem, 9vw, 8.5rem)" }}
 			>
 				<HeroNameWords state={state} lockedNames={lockedNames} />

--- a/src/features/analytics/Dashboard.tsx
+++ b/src/features/analytics/Dashboard.tsx
@@ -6,14 +6,22 @@ import {
 	Target,
 	TrendingUp,
 	Trophy,
-	User,
 	Users,
 } from "lucide-react";
 import Button from "@/shared/components/layout/Button";
 import { EmptyState } from "@/shared/components/layout/EmptyState";
 import type { SiteStats, UserStats } from "@/shared/services/supabase/statsService";
 import type { NameItem, RatingData } from "@/shared/types";
-import { ContextBadge, Panel, SectionHeader, StatTile } from "./components/DashboardPrimitives";
+import {
+	ContextBadge,
+	ListPanel,
+	ListPanelRow,
+	Panel,
+	SectionHeader,
+	StatTile,
+} from "./components/DashboardPrimitives";
+import { ProfilePanel } from "./components/ProfilePanel";
+import { themeSurfaces, themeText } from "@/shared/lib/themeClasses";
 import { LeaderboardPanel } from "./components/LeaderboardPanel";
 import { type QuickStat } from "./components/QuickStatsPanel";
 import { RatingDistributionChart } from "./components/RatingDistributionChart";
@@ -101,7 +109,7 @@ function DashboardEmptyState({
 	onStartNew?: () => void;
 }) {
 	return (
-		<Panel className="border-dashed bg-black/10">
+		<Panel className="border-dashed bg-muted/20">
 			<SectionHeader
 				icon={BarChart3}
 				title="Nothing Ranked Yet"
@@ -115,14 +123,14 @@ function DashboardEmptyState({
 				}
 			/>
 			<div className="grid gap-3 md:grid-cols-2">
-				<div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-					<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/65">
+				<div className={`${themeSurfaces.panelDense} p-4`}>
+					<p className={themeText.eyebrowWide}>
 						Personal Layer
 					</p>
 					<p className="mt-2 text-sm leading-relaxed text-muted-foreground/75">Your saved order.</p>
 				</div>
-				<div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-					<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/65">
+				<div className={`${themeSurfaces.panelDense} p-4`}>
+					<p className={themeText.eyebrowWide}>
 						Community Layer
 					</p>
 					<p className="mt-2 text-sm leading-relaxed text-muted-foreground/75">
@@ -158,30 +166,7 @@ function DashboardHeader({
 	return (
 		<div className="grid gap-4 xl:grid-cols-[minmax(0,20rem)_1fr]">
 			{isLoggedIn && userName && (
-				<Panel>
-					<div className="flex items-center gap-4">
-						{avatarUrl ? (
-							<img
-								src={avatarUrl}
-								alt={userName}
-								className="size-16 rounded-full border border-white/10 object-cover"
-							/>
-						) : (
-							<div className="flex size-16 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-primary">
-								<User size={22} />
-							</div>
-						)}
-						<div className="min-w-0">
-							<p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/65">
-								Profile
-							</p>
-							<h2 className="mt-2 truncate text-2xl font-semibold text-foreground">{userName}</h2>
-							<p className="mt-1 text-sm text-muted-foreground/75">
-								{isAdmin ? "Administrator" : "Tournament participant"}
-							</p>
-						</div>
-					</div>
-				</Panel>
+				<ProfilePanel userName={userName} isAdmin={isAdmin} avatarUrl={avatarUrl} />
 			)}
 
 			{quickStats.length > 0 && (
@@ -300,7 +285,7 @@ function EngagementPanel({
 						<select
 							value={timeframe}
 							onChange={(event) => setTimeframe(event.target.value as DashboardTimeframe)}
-							className="rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm text-foreground"
+							className={`rounded-xl px-3 py-2 text-sm text-foreground ${themeSurfaces.panelDense}`}
 						>
 							<option value="day">24 hours</option>
 							<option value="week">Week</option>
@@ -361,31 +346,30 @@ function AdminPanel({
 				}
 			/>
 			{showHiddenNames ? (
-				<div className="overflow-hidden rounded-2xl border border-white/10 bg-black/15">
+				<ListPanel>
 					{hiddenNames.length > 0 ? (
 						hiddenNames.map((name, index) => (
-							<div
+							<ListPanelRow
 								key={name.id}
-								className={`flex items-center justify-between gap-3 px-4 py-3 ${
-									index < hiddenNames.length - 1 ? "border-b border-white/10" : ""
-								}`}
+								divided={index < hiddenNames.length - 1}
+								className="justify-between"
 							>
 								<span className="text-sm font-medium text-foreground">{name.name}</span>
 								<Button variant="ghost" size="small" onClick={() => handleUnhideName(name.id)}>
 									<Eye size={14} />
 									Unhide
 								</Button>
-							</div>
+							</ListPanelRow>
 						))
 					) : (
 						<EmptyState variant="inline" title="No hidden names." />
 					)}
-				</div>
+				</ListPanel>
 			) : (
 				<EmptyState
 					variant="box"
 					title="Open the list to review and restore hidden names."
-					className="border-dashed bg-black/10"
+					className="border-dashed bg-muted/20"
 				/>
 			)}
 		</Panel>

--- a/src/features/analytics/PersonalResults.tsx
+++ b/src/features/analytics/PersonalResults.tsx
@@ -31,7 +31,7 @@ export const PersonalResults = ({
 
 	return (
 		<div className="space-y-6">
-			<div className="rounded-[1.5rem] border border-white/10 bg-black/15 p-4 sm:p-5">
+			<div className="surface-panel-inset rounded-[1.5rem] p-4 sm:p-5">
 				<div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
 					<div className="space-y-2">
 						<p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/65">

--- a/src/features/analytics/components/DashboardPrimitives.test.tsx
+++ b/src/features/analytics/components/DashboardPrimitives.test.tsx
@@ -213,13 +213,13 @@ describe("ContextBadge", () => {
 		render(<ContextBadge label="Status" />);
 		const badge = screen.getByText("Status");
 		expect(badge).toBeInTheDocument();
-		expect(badge).toHaveClass("border-white/[0.07]");
+		expect(badge).toHaveClass("border-border/35");
 	});
 
 	it("renders correctly with accent tone", () => {
 		render(<ContextBadge label="Active" tone="accent" />);
 		const badge = screen.getByText("Active");
-		expect(badge).toHaveClass("bg-primary/8");
+		expect(badge).toHaveClass("bg-primary/10");
 	});
 });
 

--- a/src/features/analytics/components/DashboardPrimitives.tsx
+++ b/src/features/analytics/components/DashboardPrimitives.tsx
@@ -8,17 +8,19 @@ import React, {
 	useState,
 } from "react";
 import { Card } from "@/shared/components/layout/Card/Card";
+import { cn } from "@/shared/lib/utils";
+import { themeSurfaces, themeText } from "@/shared/lib/themeClasses";
 
 export const CHART_TOOLTIP_STYLE = {
-	background: "rgba(14, 18, 28, 0.96)",
-	border: "1px solid rgba(255, 255, 255, 0.09)",
+	background: "var(--chart-tooltip-bg)",
+	border: "1px solid var(--chart-tooltip-border)",
 	borderRadius: 10,
 	fontSize: 12,
-	color: "#d4dce8",
-	boxShadow: "0 8px 24px rgba(0, 0, 0, 0.32)",
+	color: "var(--chart-tooltip-fg)",
+	boxShadow: "var(--chart-tooltip-shadow)",
 } as const;
 
-export const CHART_CURSOR = { fill: "rgba(63, 184, 176, 0.06)" } as const;
+export const CHART_CURSOR = { fill: "var(--chart-cursor-fill)" } as const;
 
 export function ChartFrame({
 	children,
@@ -74,6 +76,33 @@ export function Panel({ children, className = "" }: { children: ReactNode; class
 	);
 }
 
+/** Bordered list container shared by leaderboard, hidden names, and similar panels. */
+export function ListPanel({
+	children,
+	className,
+}: {
+	children: ReactNode;
+	className?: string;
+}) {
+	return <div className={cn(themeSurfaces.panelInset, className)}>{children}</div>;
+}
+
+export function ListPanelRow({
+	children,
+	divided = true,
+	className,
+}: {
+	children: ReactNode;
+	divided?: boolean;
+	className?: string;
+}) {
+	return (
+		<div className={cn("flex items-center gap-3 px-4 py-3", divided && themeSurfaces.rowDivider, className)}>
+			{children}
+		</div>
+	);
+}
+
 export function StatTile({
 	label,
 	value,
@@ -86,24 +115,14 @@ export function StatTile({
 	accent?: boolean;
 }) {
 	return (
-		<div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-white/[0.07] bg-white/[0.025] px-4 py-5 text-center">
+		<div className={themeSurfaces.statTile}>
 			{Icon && (
-				<div
-					className={`rounded-lg border p-2 ${
-						accent
-							? "border-primary/15 bg-primary/8 text-primary"
-							: "border-white/[0.07] bg-white/[0.03] text-white/40"
-					}`}
-				>
+				<div className={accent ? themeSurfaces.statIconAccent : themeSurfaces.statIcon}>
 					<Icon size={14} />
 				</div>
 			)}
-			<p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/35">{label}</p>
-			<p
-				className={`text-2xl font-semibold leading-none ${accent ? "text-primary" : "text-white/80"}`}
-			>
-				{value}
-			</p>
+			<p className={themeText.eyebrow}>{label}</p>
+			<p className={cn(themeText.statValue, accent && "text-primary")}>{value}</p>
 		</div>
 	);
 }
@@ -116,13 +135,7 @@ export function ContextBadge({
 	tone?: "default" | "accent";
 }) {
 	return (
-		<span
-			className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] ${
-				tone === "accent"
-					? "border-primary/15 bg-primary/8 text-primary/80"
-					: "border-white/[0.07] bg-white/[0.025] text-white/35"
-			}`}
-		>
+		<span className={tone === "accent" ? themeSurfaces.badgeAccent : themeSurfaces.badge}>
 			{label}
 		</span>
 	);
@@ -144,11 +157,9 @@ export function SectionHeader({
 			<div className="space-y-1.5">
 				<div className="flex items-center gap-2">
 					<Icon size={13} className="text-primary/70 shrink-0" />
-					<span className="text-xs font-semibold uppercase tracking-[0.16em] text-white/50">
-						{title}
-					</span>
+					<span className={themeText.sectionLabel}>{title}</span>
 				</div>
-				{subtitle && <p className="max-w-2xl text-sm leading-relaxed text-white/35">{subtitle}</p>}
+				{subtitle && <p className={cn("max-w-2xl", themeText.subtitle)}>{subtitle}</p>}
 			</div>
 			{action}
 		</div>

--- a/src/features/analytics/components/HiddenNamesPanel.tsx
+++ b/src/features/analytics/components/HiddenNamesPanel.tsx
@@ -1,7 +1,7 @@
 import { Eye, EyeOff } from "lucide-react";
 import Button from "@/shared/components/layout/Button";
 import { EmptyState } from "@/shared/components/layout/EmptyState";
-import { Panel, SectionHeader } from "./DashboardPrimitives";
+import { ListPanel, ListPanelRow, Panel, SectionHeader } from "./DashboardPrimitives";
 
 interface HiddenName {
 	id: string;
@@ -40,31 +40,30 @@ export function HiddenNamesPanel({
 				}
 			/>
 			{showHiddenNames ? (
-				<div className="overflow-hidden rounded-2xl border border-white/10 bg-black/15">
+				<ListPanel>
 					{hiddenNames.length > 0 ? (
 						hiddenNames.map((name, index) => (
-							<div
+							<ListPanelRow
 								key={name.id}
-								className={`flex items-center justify-between gap-3 px-4 py-3 ${
-									index < hiddenNames.length - 1 ? "border-b border-white/10" : ""
-								}`}
+								divided={index < hiddenNames.length - 1}
+								className="justify-between"
 							>
 								<span className="text-sm font-medium text-foreground">{name.name}</span>
 								<Button variant="ghost" size="small" onClick={() => handleUnhideName(name.id)}>
 									<Eye size={14} />
 									Unhide
 								</Button>
-							</div>
+							</ListPanelRow>
 						))
 					) : (
 						<EmptyState variant="inline" title="No hidden names." />
 					)}
-				</div>
+				</ListPanel>
 			) : (
 				<EmptyState
 					variant="box"
 					title="Open the list to review and restore hidden names."
-					className="border-dashed bg-black/10"
+					className="border-dashed bg-muted/20"
 				/>
 			)}
 		</Panel>

--- a/src/features/analytics/components/LeaderboardPanel.tsx
+++ b/src/features/analytics/components/LeaderboardPanel.tsx
@@ -2,7 +2,8 @@ import { Trophy } from "lucide-react";
 import Button from "@/shared/components/layout/Button";
 import { EmptyState } from "@/shared/components/layout/EmptyState";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
-import { ContextBadge, Panel, SectionHeader } from "./DashboardPrimitives";
+import { ContextBadge, ListPanel, ListPanelRow, Panel, SectionHeader } from "./DashboardPrimitives";
+import { themeSurfaces } from "@/shared/lib/themeClasses";
 
 interface LeaderboardEntry {
 	name: string;
@@ -43,15 +44,15 @@ export function LeaderboardPanel({
 			{isLoadingLeaderboard ? (
 				<Loading variant="skeleton" height={320} />
 			) : leaderboard.length > 0 ? (
-				<div className="overflow-hidden rounded-2xl border border-white/10 bg-black/15">
+				<ListPanel>
 					{leaderboard.map((entry, index) => (
-						<div
+						<ListPanelRow
 							key={entry.name}
-							className={`flex items-center gap-3 px-4 py-3 ${
-								index < leaderboard.length - 1 ? "border-b border-white/10" : ""
-							}`}
+							divided={index < leaderboard.length - 1}
 						>
-							<div className="flex size-9 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-sm font-semibold text-foreground">
+							<div
+								className={`flex size-9 items-center justify-center rounded-full text-sm font-semibold text-foreground ${themeSurfaces.avatar}`}
+							>
 								{index + 1}
 							</div>
 							<div className="min-w-0 flex-1">
@@ -65,9 +66,9 @@ export function LeaderboardPanel({
 							<div className="text-right">
 								<p className="text-lg font-semibold text-primary">{Math.round(entry.avg_rating)}</p>
 							</div>
-						</div>
+						</ListPanelRow>
 					))}
-				</div>
+				</ListPanel>
 			) : (
 				<EmptyState
 					variant="box"

--- a/src/features/analytics/components/ProfilePanel.tsx
+++ b/src/features/analytics/components/ProfilePanel.tsx
@@ -1,4 +1,5 @@
 import { User } from "lucide-react";
+import { themeSurfaces, themeText } from "@/shared/lib/themeClasses";
 import { Panel } from "./DashboardPrimitives";
 
 interface ProfilePanelProps {
@@ -15,15 +16,17 @@ export function ProfilePanel({ userName, isAdmin, avatarUrl }: ProfilePanelProps
 					<img
 						src={avatarUrl}
 						alt={userName}
-						className="size-16 rounded-full border border-white/10 object-cover"
+						className={`size-16 rounded-full object-cover ${themeSurfaces.avatar}`}
 					/>
 				) : (
-					<div className="flex size-16 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-primary">
+					<div
+						className={`flex size-16 items-center justify-center rounded-full text-primary ${themeSurfaces.avatar}`}
+					>
 						<User size={22} />
 					</div>
 				)}
 				<div className="min-w-0">
-					<p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/65">
+					<p className={themeText.eyebrowWide}>
 						Profile
 					</p>
 					<h2 className="mt-2 truncate text-2xl font-semibold text-foreground">{userName}</h2>

--- a/src/features/analytics/components/RatingDistributionChart.tsx
+++ b/src/features/analytics/components/RatingDistributionChart.tsx
@@ -75,7 +75,7 @@ export function RatingDistributionChart({ leaderboard }: RatingDistributionChart
 
 	if (data.length === 0) {
 		return (
-			<div className="flex h-40 items-center justify-center rounded-2xl border border-dashed border-white/10 bg-black/15 px-4 text-center text-sm text-muted-foreground/70">
+			<div className="surface-panel-inset flex h-40 items-center justify-center rounded-2xl border border-dashed px-4 text-center text-sm text-muted-foreground/70">
 				Not enough rated names yet to draw a distribution.
 			</div>
 		);

--- a/src/features/analytics/components/RecentActivityPanel.tsx
+++ b/src/features/analytics/components/RecentActivityPanel.tsx
@@ -38,7 +38,7 @@ export function RecentActivityPanel({
 						<select
 							value={timeframe}
 							onChange={(event) => setTimeframe(event.target.value as DashboardTimeframe)}
-							className="rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm text-foreground"
+							className="surface-panel-inset rounded-xl px-3 py-2 text-sm text-foreground"
 						>
 							<option value="day">24 hours</option>
 							<option value="week">Week</option>

--- a/src/features/analytics/components/WinLossChart.tsx
+++ b/src/features/analytics/components/WinLossChart.tsx
@@ -25,7 +25,7 @@ export function WinLossChart({ leaderboard, limit = 8 }: WinLossChartProps) {
 
 	if (data.length === 0) {
 		return (
-			<div className="flex h-40 items-center justify-center rounded-2xl border border-dashed border-white/10 bg-black/15 px-4 text-center text-sm text-muted-foreground/70">
+			<div className="surface-panel-inset flex h-40 items-center justify-center rounded-2xl border border-dashed px-4 text-center text-sm text-muted-foreground/70">
 				No head-to-head matches recorded yet. Run a tournament to populate this chart.
 			</div>
 		);

--- a/src/features/analytics/components/WordCloudChart.tsx
+++ b/src/features/analytics/components/WordCloudChart.tsx
@@ -23,31 +23,24 @@ function WordTooltip({ name, avgRating, wins, totalRatings }: TooltipProps) {
 	return (
 		<div className="pointer-events-none absolute left-1/2 top-full z-30 mt-3 -translate-x-1/2 translate-y-1 opacity-0 transition-all duration-200 ease-out group-hover:translate-y-0 group-hover:opacity-100">
 			{/* Caret */}
-			<div className="mx-auto mb-[-1px] h-0 w-0 border-l-[6px] border-r-[6px] border-b-[6px] border-l-transparent border-r-transparent border-b-white/10" />
-			{/* Card */}
-			<div
-				className="min-w-[148px] rounded-[1.1rem] border border-white/10 px-3.5 py-3 text-left shadow-[0_24px_56px_rgba(0,0,0,0.55),0_0_0_1px_rgba(255,255,255,0.04)] backdrop-blur-xl"
-				style={{ background: "rgba(12,14,22,0.92)" }}
-			>
-				{/* Name */}
-				<p className="mb-2 text-[13px] font-bold leading-none tracking-tight text-white">{name}</p>
-				{/* Divider */}
-				<div className="mb-2 h-px bg-white/8" />
-				{/* Stats row */}
+			<div className="mx-auto mb-[-1px] h-0 w-0 border-l-[6px] border-r-[6px] border-b-[6px] border-l-transparent border-r-transparent border-b-border/50" />
+			<div className="surface-panel min-w-[148px] rounded-[1.1rem] px-3.5 py-3 text-left shadow-lg">
+				<p className="mb-2 text-[13px] font-bold leading-none tracking-tight text-foreground">{name}</p>
+				<div className="mb-2 h-px bg-border/40" />
 				<div className="flex flex-col gap-1.5">
 					<div className="flex items-center justify-between gap-6">
-						<span className="text-[11px] text-white/45">Avg rating</span>
-						<span className="text-[11px] font-semibold tabular-nums text-white/90">
+						<span className="text-[11px] text-muted-foreground/70">Avg rating</span>
+						<span className="text-[11px] font-semibold tabular-nums text-foreground/90">
 							{Math.round(avgRating)}
 						</span>
 					</div>
 					<div className="flex items-center justify-between gap-6">
-						<span className="text-[11px] text-white/45">Wins</span>
-						<span className="text-[11px] font-semibold tabular-nums text-white/90">{wins}</span>
+						<span className="text-[11px] text-muted-foreground/70">Wins</span>
+						<span className="text-[11px] font-semibold tabular-nums text-foreground/90">{wins}</span>
 					</div>
 					<div className="flex items-center justify-between gap-6">
-						<span className="text-[11px] text-white/45">Win rate</span>
-						<span className="text-[11px] font-semibold tabular-nums text-white/90">{winRate}%</span>
+						<span className="text-[11px] text-muted-foreground/70">Win rate</span>
+						<span className="text-[11px] font-semibold tabular-nums text-foreground/90">{winRate}%</span>
 					</div>
 				</div>
 			</div>
@@ -64,12 +57,12 @@ export function WordCloudChart({ leaderboard }: WordCloudChartProps) {
 				index % 5 === 0
 					? "text-primary"
 					: index % 5 === 1
-						? "text-white/95"
+						? "text-foreground/95"
 						: index % 5 === 2
-							? "text-white/82"
+							? "text-foreground/82"
 							: index % 5 === 3
-								? "text-white/68"
-								: "text-white/54";
+								? "text-foreground/68"
+								: "text-muted-foreground/75";
 			return { ...entry, size, tone };
 		});
 

--- a/src/shared/components/layout/EmptyState.tsx
+++ b/src/shared/components/layout/EmptyState.tsx
@@ -1,4 +1,5 @@
 import type { ElementType, ReactNode } from "react";
+import { themeSurfaces } from "@/shared/lib/themeClasses";
 import { cn } from "@/shared/lib/utils";
 
 interface EmptyStateProps {
@@ -20,7 +21,8 @@ export function EmptyState({
 		return (
 			<div
 				className={cn(
-					"rounded-2xl border border-white/10 bg-black/15 px-4 py-8 text-center text-sm text-muted-foreground/75",
+					themeSurfaces.panelInset,
+					"px-4 py-8 text-center text-sm text-muted-foreground/75",
 					className,
 				)}
 			>

--- a/src/shared/components/layout/Surface.tsx
+++ b/src/shared/components/layout/Surface.tsx
@@ -1,25 +1,23 @@
 import { type ElementType, type ReactNode } from "react";
 import { cn } from "@/shared/lib/utils";
+import { themeSurfaces } from "@/shared/lib/themeClasses";
 
-type SurfaceTone = "glass" | "muted" | "transparent";
+type SurfaceTone = "glass" | "muted" | "inset" | "transparent";
 type SurfacePadding = "none" | "compact" | "comfortable";
-type SurfaceRadius = "md" | "lg" | "xl";
 
 interface SurfaceProps {
 	children: ReactNode;
 	as?: ElementType;
 	tone?: SurfaceTone;
 	padding?: SurfacePadding;
-	radius?: SurfaceRadius;
-	bordered?: boolean;
-	elevated?: boolean;
 	className?: string;
 }
 
 const toneClasses: Record<SurfaceTone, string> = {
-	glass: "bg-white/[0.04] backdrop-blur-xl",
-	muted: "bg-black/15",
-	transparent: "bg-transparent",
+	glass: themeSurfaces.panel,
+	muted: themeSurfaces.panel,
+	inset: themeSurfaces.panelInset,
+	transparent: "rounded-2xl border-transparent bg-transparent shadow-none",
 };
 
 const paddingClasses: Record<SurfacePadding, string> = {
@@ -28,37 +26,18 @@ const paddingClasses: Record<SurfacePadding, string> = {
 	comfortable: "p-4 sm:p-6",
 };
 
-const radiusClasses: Record<SurfaceRadius, string> = {
-	md: "rounded-2xl",
-	lg: "rounded-[1.75rem]",
-	xl: "rounded-[1.85rem]",
-};
-
 /**
  * Shared bordered/blurred surface used across panels, cards, and section wrappers.
- * Replaces ad-hoc `rounded-[…] border border-white/10 bg-white/[0.04]` patterns.
  */
 export function Surface({
 	children,
 	as: Component = "section",
 	tone = "glass",
 	padding = "comfortable",
-	radius = "lg",
-	bordered = true,
-	elevated = false,
 	className = "",
 }: SurfaceProps) {
 	return (
-		<Component
-			className={cn(
-				radiusClasses[radius],
-				toneClasses[tone],
-				paddingClasses[padding],
-				bordered && "border border-white/10",
-				elevated && "shadow-[0_16px_40px_rgba(4,10,20,0.14)]",
-				className,
-			)}
-		>
+		<Component className={cn(toneClasses[tone], paddingClasses[padding], className)}>
 			{children}
 		</Component>
 	);

--- a/src/shared/lib/themeClasses.ts
+++ b/src/shared/lib/themeClasses.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared Tailwind class groups aligned with design tokens in src/styles/tokens.css.
+ * Prefer these over ad-hoc border-white/10 and bg-black/15 patterns.
+ */
+export const themeSurfaces = {
+	panel: "rounded-2xl border border-border/50 bg-card/45 backdrop-blur-xl shadow-sm",
+	panelInset: "overflow-hidden rounded-2xl border border-border/40 bg-muted/30",
+	panelDense: "rounded-xl border border-border/40 bg-card/35",
+	rowDivider: "border-b border-border/40 last:border-b-0",
+	avatar: "border border-border/50 bg-foreground/[0.04]",
+	statTile:
+		"flex flex-col items-center justify-center gap-2 rounded-xl border border-border/35 bg-card/30 px-4 py-5 text-center",
+	statIcon: "rounded-lg border border-border/35 bg-foreground/[0.03] text-muted-foreground/70",
+	statIconAccent: "rounded-lg border border-primary/20 bg-primary/10 text-primary",
+	badge:
+		"inline-flex items-center rounded-full border border-border/35 bg-card/25 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/60",
+	badgeAccent:
+		"inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-primary/85",
+} as const;
+
+export const themeText = {
+	eyebrow: "text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/60",
+	eyebrowWide: "text-[11px] font-semibold uppercase tracking-[0.28em] text-muted-foreground/55",
+	sectionLabel: "text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground/65",
+	subtitle: "text-sm leading-relaxed text-muted-foreground/55",
+	statValue: "text-2xl font-semibold leading-none text-foreground/90",
+	heroDisplay: "font-black uppercase leading-[0.88] tracking-tighter text-foreground",
+	heroPlaceholder: "text-muted-foreground/25",
+} as const;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./tokens.css";
+@import "./surfaces.css";
 @import "./reset.css";
 @import "./typography.css";
 @import "./layout.css";

--- a/src/styles/surfaces.css
+++ b/src/styles/surfaces.css
@@ -1,0 +1,42 @@
+/**
+ * @file surfaces.css
+ * @description Semantic surface utilities backed by design tokens.
+ */
+
+@layer utilities {
+	.surface-panel {
+		border-radius: var(--radius-xl);
+		border: 1px solid var(--glass-border);
+		background: var(--glass-bg);
+		backdrop-filter: blur(var(--glass-blur));
+		box-shadow: var(--shadow-sm);
+	}
+
+	.surface-panel-inset {
+		overflow: hidden;
+		border-radius: var(--radius-xl);
+		border: 1px solid var(--glass-border);
+		background: color-mix(in srgb, var(--card) 35%, transparent);
+	}
+
+	.surface-avatar {
+		border: 1px solid var(--glass-border-hover);
+		background: color-mix(in srgb, var(--foreground) 4%, transparent);
+	}
+
+	.text-eyebrow {
+		font-size: 0.625rem;
+		font-weight: 600;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: color-mix(in srgb, var(--muted-foreground) 60%, transparent);
+	}
+
+	.text-eyebrow-wide {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.28em;
+		text-transform: uppercase;
+		color: color-mix(in srgb, var(--muted-foreground) 55%, transparent);
+	}
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,43 +11,27 @@
    ========================================================================== */
 
 :root {
-	--background: hsl(0deg 0% 100%);
-	--foreground: hsl(0deg 0% 0%);
-	--card: hsl(0deg 0% 100%);
-	--card-foreground: hsl(0deg 0% 0%);
-	--popover: hsl(0deg 0% 100%);
-	--popover-foreground: hsl(0deg 0% 0%);
-	--primary: hsl(0deg 0% 0%);
-	--primary-foreground: hsl(0deg 0% 100%);
-	--secondary: hsl(0deg 0% 96%);
-	--secondary-foreground: hsl(0deg 0% 0%);
-	--muted: hsl(0deg 0% 96%);
-	--muted-foreground: hsl(0deg 0% 45%);
-	--accent: hsl(0deg 0% 90%);
-	--accent-foreground: hsl(0deg 0% 0%);
-	--destructive: hsl(0deg 84% 60%);
+	/* Light-mode fallbacks; dark palette overrides below */
+	--destructive: hsl(6deg 68% 52%);
 	--destructive-foreground: hsl(0deg 0% 98%);
-	--success: hsl(142deg 71% 45%);
+	--success: hsl(190deg 55% 34%);
 	--success-foreground: hsl(0deg 0% 100%);
-	--warning: hsl(38deg 92% 50%);
-	--warning-foreground: hsl(0deg 0% 100%);
-	--border: hsl(0deg 0% 0%);
-	--input: hsl(0deg 0% 0%);
-	--ring: hsl(0deg 0% 0%);
-	--chart-1: hsl(12deg 76% 61%);
-	--chart-2: hsl(173deg 58% 39%);
-	--chart-3: hsl(197deg 37% 24%);
-	--chart-4: hsl(43deg 74% 66%);
-	--chart-5: hsl(27deg 87% 67%);
-	--accent-color: hsl(190deg 100% 50%);
-	--navbar: hsl(0deg 0% 98%);
-	--navbar-foreground: hsl(0deg 0% 0%);
-	--navbar-primary: hsl(0deg 0% 0%);
+	--warning: hsl(42deg 82% 60%);
+	--warning-foreground: hsl(224deg 28% 12%);
+	--chart-1: hsl(18deg 68% 56%);
+	--chart-2: hsl(190deg 58% 38%);
+	--chart-3: hsl(227deg 18% 28%);
+	--chart-4: hsl(42deg 82% 60%);
+	--chart-5: hsl(330deg 73% 64%);
+	--accent-color: hsl(190deg 72% 53%);
+	--navbar: hsl(210deg 33% 99%);
+	--navbar-foreground: hsl(220deg 24% 16%);
+	--navbar-primary: hsl(190deg 55% 34%);
 	--navbar-primary-foreground: hsl(0deg 0% 100%);
-	--navbar-accent: hsl(0deg 0% 90%);
-	--navbar-accent-foreground: hsl(0deg 0% 0%);
-	--navbar-border: hsl(0deg 0% 0%);
-	--navbar-ring: hsl(0deg 0% 0%);
+	--navbar-accent: hsl(16deg 71% 53%);
+	--navbar-accent-foreground: hsl(0deg 0% 100%);
+	--navbar-border: hsl(214deg 26% 78%);
+	--navbar-ring: hsl(190deg 55% 34%);
 	--font-sans:
 		"Space Grotesk", ui-sans-serif, system-ui, -apple-system, blinkmacsystemfont, "Segoe UI",
 		roboto, "Helvetica Neue", arial, "Noto Sans", sans-serif;
@@ -59,7 +43,7 @@
 	--font-mono:
 		"Space Mono", ui-monospace, sfmono-regular, menlo, monaco, consolas, "Liberation Mono",
 		"Courier New", monospace;
-	--radius: 0rem;
+	--radius: 0.75rem;
 	--shadow-2xs: 1px 1px 0px 0px var(--color-neutral-900);
 	--shadow-xs: 2px 2px 0px 0px var(--color-neutral-900);
 	--shadow-sm: 3px 3px 0px 0px var(--color-neutral-900);
@@ -341,24 +325,24 @@
    ========================================================================== */
 :root {
 	/* Core palette (HSL tuples for Tailwind + semantic binding) */
-	--pw-sage-hsl: 190 55% 34%;
-	--pw-coral-hsl: 16 71% 53%;
+	--pw-sage-hsl: 190 58% 38%;
+	--pw-coral-hsl: 18 68% 56%;
 	--pw-sand-hsl: 31 28% 58%;
-	--pw-indigo-hsl: 227 18% 18%;
+	--pw-indigo-hsl: 224 22% 14%;
 	--pw-mimosa-hsl: 42 82% 60%;
 	--pw-danger-hsl: 6 68% 52%;
 	--pw-info-hsl: 212 78% 61%;
 	--pw-lavender-hsl: 246 52% 87%;
 	--pw-rose-hsl: 330 73% 64%;
 
-	/* Dark defaults */
-	--pw-bg-0: #111318;
-	--pw-bg-1: #171b23;
-	--pw-bg-2: #1f2631;
-	--pw-bg-3: #283140;
-	--pw-text-strong: #ebf1f7;
-	--pw-text-base: #d2dbe6;
-	--pw-text-muted: #a7b0bb;
+	/* Dark defaults — aligned with app shell and PWA manifest */
+	--pw-bg-0: #0a0e14;
+	--pw-bg-1: #121820;
+	--pw-bg-2: #1a222c;
+	--pw-bg-3: #232d3a;
+	--pw-text-strong: #eef3f9;
+	--pw-text-base: #c8d4e0;
+	--pw-text-muted: #8f9bab;
 	--pw-border-soft: color-mix(in srgb, var(--pw-text-strong) 16%, transparent);
 	--pw-border-strong: color-mix(in srgb, var(--pw-text-strong) 28%, transparent);
 
@@ -395,6 +379,14 @@
 	--pw-heading-gradient-from: hsl(var(--pw-sage-hsl));
 	--pw-heading-gradient-to: hsl(var(--pw-coral-hsl));
 
+	/* Chart / data-viz chrome */
+	--chart-tooltip-bg: color-mix(in srgb, var(--card) 96%, transparent);
+	--chart-tooltip-border: color-mix(in srgb, var(--foreground) 9%, transparent);
+	--chart-tooltip-fg: var(--pw-text-base);
+	--chart-tooltip-shadow: 0 8px 24px color-mix(in srgb, var(--background-color) 55%, transparent);
+	--chart-cursor-fill: color-mix(in srgb, hsl(var(--pw-sage-hsl)) 8%, transparent);
+	--app-boot-bg: var(--pw-bg-0);
+
 	/* Tailwind color tuple support */
 	--charcoal: 227 18% 18%;
 	--blue-gray: 214 22% 31%;
@@ -426,21 +418,26 @@
 	--primary-color: hsl(var(--pw-sage-hsl));
 	--primary-light: color-mix(in srgb, hsl(var(--pw-sage-hsl)) 68%, white);
 	--primary-dark: color-mix(in srgb, hsl(var(--pw-sage-hsl)) 76%, black);
-	--background: hsl(224deg 28% 7%);
-	--foreground: hsl(210deg 30% 94%);
-	--card: hsl(222deg 24% 10%);
-	--card-foreground: hsl(210deg 30% 94%);
-	--popover: hsl(222deg 24% 10%);
-	--popover-foreground: hsl(210deg 30% 94%);
+	--background: hsl(224deg 28% 6%);
+	--foreground: hsl(210deg 32% 95%);
+	--card: hsl(222deg 22% 11%);
+	--card-foreground: hsl(210deg 32% 95%);
+	--popover: hsl(222deg 22% 11%);
+	--popover-foreground: hsl(210deg 32% 95%);
 	--primary: hsl(var(--pw-sage-hsl));
 	--primary-foreground: hsl(0deg 0% 100%);
-	--secondary: hsl(218deg 20% 16%);
-	--secondary-foreground: hsl(210deg 30% 94%);
+	--secondary: hsl(218deg 18% 17%);
+	--secondary-foreground: hsl(210deg 28% 90%);
 	--accent: hsl(var(--pw-coral-hsl));
 	--accent-foreground: hsl(0deg 0% 100%);
-	--border: hsl(220deg 18% 22%);
-	--input: hsl(220deg 18% 22%);
+	--border: hsl(220deg 16% 24%);
+	--input: hsl(220deg 16% 24%);
 	--ring: hsl(var(--pw-sage-hsl));
+	--chart-1: hsl(var(--pw-coral-hsl));
+	--chart-2: hsl(var(--pw-sage-hsl));
+	--chart-3: hsl(var(--pw-indigo-hsl));
+	--chart-4: hsl(var(--pw-mimosa-hsl));
+	--chart-5: hsl(var(--pw-rose-hsl));
 
 	/* Surface colors */
 	--surface-color: var(--pw-bg-1);
@@ -524,8 +521,8 @@
 	);
 	--namecard-selected-border: color-mix(in srgb, hsl(var(--pw-sage-hsl)) 62%, white);
 	--namecard-selected-description: color-mix(in srgb, hsl(var(--pw-sage-hsl)) 82%, white);
-	--muted: #1d2630;
-	--muted-foreground: #c8d2de;
+	--muted: hsl(218deg 18% 15%);
+	--muted-foreground: hsl(214deg 14% 68%);
 
 	/* Navigation tokens */
 	--nav-bg: color-mix(in srgb, var(--surface-muted) 80%, transparent);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR makes the visual system more intentional by refining the dark sage-and-coral palette, aligning shell/PWA colors with design tokens, and replacing scattered `border-white/10` / `bg-black/15` patterns with shared semantic utilities.

## Changes

- **Design tokens** (`src/styles/tokens.css`): Refined brand colors, warmer night backgrounds (`#0a0e14`), softer default radius (`0.75rem`), chart colors tied to sage/coral, and chart-tooltip CSS variables.
- **Shared utilities**: Added `src/shared/lib/themeClasses.ts` and `src/styles/surfaces.css` for reusable panel, badge, and typography classes.
- **Dashboard cohesion**: `DashboardPrimitives` now exposes `ListPanel` / `ListPanelRow`; analytics panels, charts, and empty states use token-backed surfaces.
- **App shell alignment**: Home hero, boot screen, `index.html`, and `manifest.json` use the same background and gradient tokens.

## Testing

- `pnpm test` — 343 tests passed
- `pnpm build` — succeeded

## Screenshots

N/A (styling-only change; verify in browser on home, dashboard, and boot screen).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf1845bc-eeed-4296-bbd2-109f8705db5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf1845bc-eeed-4296-bbd2-109f8705db5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

