### PR TITLE
Make all home sections full-page with nav buttons

### DIFF
--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
+import { motion } from "framer-motion";
 import { errorContexts, routeComponents } from "@/app/appConfig";
 import { HomeHeroSection } from "@/app/routes/components/HomeSections";
 import { namesQueryOptions } from "@/shared/api/names/api";
@@ -84,14 +85,39 @@ export default function HomeRoute() {
 			/>
 
 			<Section id="pick" variant="minimal" padding="comfortable" maxWidth="xl" separator={true} fullpage={true}>
-				<SectionHeading title="Narrow It Down" subtitle="Select your top picks." />
-				<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-					<TournamentFlow />
-				</Suspense>
-				<div className="mt-8 flex justify-center">
-					<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-						Continue to Bracket
-					</Button>
+				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+						<motion.div
+							initial={{ opacity: 0, y: 20 }}
+							whileInView={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.6, ease: "easeOut" }}
+							viewport={{ once: false }}
+						>
+							<SectionHeading title="Narrow It Down" subtitle="Select your top picks." />
+						</motion.div>
+						<motion.div
+							initial={{ opacity: 0, scale: 0.95 }}
+							whileInView={{ opacity: 1, scale: 1 }}
+							transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
+							viewport={{ once: false }}
+							className="w-full"
+						>
+							<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+								<TournamentFlow />
+							</Suspense>
+						</motion.div>
+						<motion.div
+							initial={{ opacity: 0, y: 20 }}
+							whileInView={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.6, ease: "easeOut", delay: 0.2 }}
+							viewport={{ once: false }}
+							className="mt-auto pt-8 flex justify-center"
+						>
+							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
+								Continue to Bracket
+							</Button>
+						</motion.div>
+					</div>
 				</div>
 			</Section>
 
@@ -103,35 +129,66 @@ export default function HomeRoute() {
 				separator={true}
 				fullpage={true}
 			>
-				<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
-				<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-					{tournament.names && tournament.names.length > 0 ? (
-						<>
-							<LazyTournament
-								names={tournament.names}
-								existingRatings={tournament.ratings}
-								onComplete={(ratings) => {
-									tournamentActions.completeTournament(ratings);
-									scheduleAnalysisScroll();
-								}}
-							/>
-							<div className="mt-8 flex justify-center">
-								<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
-									View Rankings
-								</Button>
-							</div>
-						</>
-					) : (
-						<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 py-12 text-center">
-							<p className="text-pretty text-sm text-muted-foreground/70">
-								Select at least two names to begin.
-							</p>
-							<Button variant="glass" onClick={() => scrollToSection("pick")}>
-								Go Back
-							</Button>
-						</div>
-					)}
-				</Suspense>
+				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+						<motion.div
+							initial={{ opacity: 0, y: 20 }}
+							whileInView={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.6, ease: "easeOut" }}
+							viewport={{ once: false }}
+						>
+							<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
+						</motion.div>
+						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+							{tournament.names && tournament.names.length > 0 ? (
+								<>
+									<motion.div
+										initial={{ opacity: 0, scale: 0.95 }}
+										whileInView={{ opacity: 1, scale: 1 }}
+										transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
+										viewport={{ once: false }}
+										className="w-full"
+									>
+										<LazyTournament
+											names={tournament.names}
+											existingRatings={tournament.ratings}
+											onComplete={(ratings) => {
+												tournamentActions.completeTournament(ratings);
+												scheduleAnalysisScroll();
+											}}
+										/>
+									</motion.div>
+									<motion.div
+										initial={{ opacity: 0, y: 20 }}
+										whileInView={{ opacity: 1, y: 0 }}
+										transition={{ duration: 0.6, ease: "easeOut", delay: 0.2 }}
+										viewport={{ once: false }}
+										className="mt-auto pt-8 flex justify-center"
+									>
+										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
+											View Rankings
+										</Button>
+									</motion.div>
+								</>
+							) : (
+								<motion.div
+									initial={{ opacity: 0, y: 20 }}
+									whileInView={{ opacity: 1, y: 0 }}
+									transition={{ duration: 0.6, ease: "easeOut" }}
+									viewport={{ once: false }}
+									className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center"
+								>
+									<p className="text-pretty text-sm text-muted-foreground/70">
+										Select at least two names to begin.
+									</p>
+									<Button variant="glass" onClick={() => scrollToSection("pick")}>
+										Go Back
+									</Button>
+								</motion.div>
+							)}
+						</Suspense>
+					</div>
+				</div>
 			</Section>
 
 			<Section
@@ -142,25 +199,50 @@ export default function HomeRoute() {
 				separator={true}
 				fullpage={true}
 			>
-				<SectionHeading title="Your Rankings" subtitle="Final scores." />
-				<Suspense fallback={<Loading variant="skeleton" height={600} />}>
-					<ErrorBoundary context={errorContexts.analysisDashboard}>
-						<DashboardLazy
-							personalRatings={tournament.ratings}
-							currentTournamentNames={tournament.names ?? undefined}
-							onStartNew={handleStartNewTournament}
-							onUpdateRatings={tournamentActions.setRatings}
-							userName={user.name ?? ""}
-							isAdmin={user.isAdmin}
-							isLoggedIn={user.isLoggedIn}
-							avatarUrl={user.avatarUrl}
-						/>
-					</ErrorBoundary>
-				</Suspense>
-				<div className="mt-8 flex justify-center">
-					<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-						Start Over
-					</Button>
+				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+						<motion.div
+							initial={{ opacity: 0, y: 20 }}
+							whileInView={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.6, ease: "easeOut" }}
+							viewport={{ once: false }}
+						>
+							<SectionHeading title="Your Rankings" subtitle="Final scores." />
+						</motion.div>
+						<motion.div
+							initial={{ opacity: 0, scale: 0.95 }}
+							whileInView={{ opacity: 1, scale: 1 }}
+							transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
+							viewport={{ once: false }}
+							className="w-full"
+						>
+							<Suspense fallback={<Loading variant="skeleton" height={600} />}>
+								<ErrorBoundary context={errorContexts.analysisDashboard}>
+									<DashboardLazy
+										personalRatings={tournament.ratings}
+										currentTournamentNames={tournament.names ?? undefined}
+										onStartNew={handleStartNewTournament}
+										onUpdateRatings={tournamentActions.setRatings}
+										userName={user.name ?? ""}
+										isAdmin={user.isAdmin}
+										isLoggedIn={user.isLoggedIn}
+										avatarUrl={user.avatarUrl}
+									/>
+								</ErrorBoundary>
+							</Suspense>
+						</motion.div>
+						<motion.div
+							initial={{ opacity: 0, y: 20 }}
+							whileInView={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.6, ease: "easeOut", delay: 0.2 }}
+							viewport={{ once: false }}
+							className="mt-auto pt-8 flex justify-center"
+						>
+							<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
+								Start Over
+							</Button>
+						</motion.div>
+					</div>
 				</div>
 			</Section>
 		</>

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -94,9 +94,12 @@ export default function HomeRoute() {
 								<TournamentFlow />
 							</Suspense>
 						</div>
-						<div className="mt-auto pt-8 flex justify-center">
+						<div className="mt-auto pt-8 flex justify-center gap-4">
+							<Button variant="glass" size="lg" onClick={() => scrollToSection("")}>
+								↑ Previous
+							</Button>
 							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								Continue to Bracket
+								Next ↓
 							</Button>
 						</div>
 					</div>
@@ -129,9 +132,12 @@ export default function HomeRoute() {
 											}}
 										/>
 									</div>
-									<div className="mt-auto pt-8 flex justify-center">
+									<div className="mt-auto pt-8 flex justify-center gap-4">
+										<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
+											↑ Previous
+										</Button>
 										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
-											View Rankings
+											Next ↓
 										</Button>
 									</div>
 								</>
@@ -179,7 +185,10 @@ export default function HomeRoute() {
 								</ErrorBoundary>
 							</Suspense>
 						</div>
-						<div className="mt-auto pt-8 flex justify-center">
+						<div className="mt-auto pt-8 flex justify-center gap-4">
+							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
+								↑ Previous
+							</Button>
 							<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
 								Start Over
 							</Button>

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -83,7 +83,7 @@ export default function HomeRoute() {
 				onStartPicking={() => scrollToSection("pick")}
 			/>
 
-			<Section id="pick" variant="minimal" padding="comfortable" maxWidth="xl" separator={true}>
+			<Section id="pick" variant="minimal" padding="comfortable" maxWidth="xl" separator={true} fullpage={true}>
 				<SectionHeading title="Narrow It Down" subtitle="Select your top picks." />
 				<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 					<TournamentFlow />
@@ -96,6 +96,7 @@ export default function HomeRoute() {
 				padding="comfortable"
 				maxWidth="2xl"
 				separator={true}
+				fullpage={true}
 			>
 				<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
 				<Suspense fallback={<Loading variant="skeleton" height={400} />}>
@@ -127,6 +128,7 @@ export default function HomeRoute() {
 				padding="comfortable"
 				maxWidth="2xl"
 				separator={true}
+				fullpage={true}
 			>
 				<SectionHeading title="Your Rankings" subtitle="Final scores." />
 				<Suspense fallback={<Loading variant="skeleton" height={600} />}>

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -88,6 +88,11 @@ export default function HomeRoute() {
 				<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 					<TournamentFlow />
 				</Suspense>
+				<div className="mt-8 flex justify-center">
+					<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
+						Continue to Bracket
+					</Button>
+				</div>
 			</Section>
 
 			<Section
@@ -101,14 +106,21 @@ export default function HomeRoute() {
 				<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
 				<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 					{tournament.names && tournament.names.length > 0 ? (
-						<LazyTournament
-							names={tournament.names}
-							existingRatings={tournament.ratings}
-							onComplete={(ratings) => {
-								tournamentActions.completeTournament(ratings);
-								scheduleAnalysisScroll();
-							}}
-						/>
+						<>
+							<LazyTournament
+								names={tournament.names}
+								existingRatings={tournament.ratings}
+								onComplete={(ratings) => {
+									tournamentActions.completeTournament(ratings);
+									scheduleAnalysisScroll();
+								}}
+							/>
+							<div className="mt-8 flex justify-center">
+								<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
+									View Rankings
+								</Button>
+							</div>
+						</>
 					) : (
 						<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 py-12 text-center">
 							<p className="text-pretty text-sm text-muted-foreground/70">
@@ -145,6 +157,11 @@ export default function HomeRoute() {
 						/>
 					</ErrorBoundary>
 				</Suspense>
+				<div className="mt-8 flex justify-center">
+					<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
+						Start Over
+					</Button>
+				</div>
 			</Section>
 		</>
 	);

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
-import { motion } from "framer-motion";
 import { errorContexts, routeComponents } from "@/app/appConfig";
 import { HomeHeroSection } from "@/app/routes/components/HomeSections";
 import { namesQueryOptions } from "@/shared/api/names/api";
@@ -87,36 +86,19 @@ export default function HomeRoute() {
 			<Section id="pick" variant="minimal" padding="comfortable" maxWidth="xl" separator={true} fullpage={true}>
 				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.6, ease: "easeOut" }}
-							viewport={{ once: false }}
-						>
+						<div>
 							<SectionHeading title="Narrow It Down" subtitle="Select your top picks." />
-						</motion.div>
-						<motion.div
-							initial={{ opacity: 0, scale: 0.95 }}
-							whileInView={{ opacity: 1, scale: 1 }}
-							transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
-							viewport={{ once: false }}
-							className="w-full"
-						>
+						</div>
+						<div className="w-full">
 							<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 								<TournamentFlow />
 							</Suspense>
-						</motion.div>
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.6, ease: "easeOut", delay: 0.2 }}
-							viewport={{ once: false }}
-							className="mt-auto pt-8 flex justify-center"
-						>
+						</div>
+						<div className="mt-auto pt-8 flex justify-center">
 							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
 								Continue to Bracket
 							</Button>
-						</motion.div>
+						</div>
 					</div>
 				</div>
 			</Section>
@@ -131,24 +113,13 @@ export default function HomeRoute() {
 			>
 				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.6, ease: "easeOut" }}
-							viewport={{ once: false }}
-						>
+						<div>
 							<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
-						</motion.div>
+						</div>
 						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 							{tournament.names && tournament.names.length > 0 ? (
 								<>
-									<motion.div
-										initial={{ opacity: 0, scale: 0.95 }}
-										whileInView={{ opacity: 1, scale: 1 }}
-										transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
-										viewport={{ once: false }}
-										className="w-full"
-									>
+									<div className="w-full">
 										<LazyTournament
 											names={tournament.names}
 											existingRatings={tournament.ratings}
@@ -157,34 +128,22 @@ export default function HomeRoute() {
 												scheduleAnalysisScroll();
 											}}
 										/>
-									</motion.div>
-									<motion.div
-										initial={{ opacity: 0, y: 20 }}
-										whileInView={{ opacity: 1, y: 0 }}
-										transition={{ duration: 0.6, ease: "easeOut", delay: 0.2 }}
-										viewport={{ once: false }}
-										className="mt-auto pt-8 flex justify-center"
-									>
+									</div>
+									<div className="mt-auto pt-8 flex justify-center">
 										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
 											View Rankings
 										</Button>
-									</motion.div>
+									</div>
 								</>
 							) : (
-								<motion.div
-									initial={{ opacity: 0, y: 20 }}
-									whileInView={{ opacity: 1, y: 0 }}
-									transition={{ duration: 0.6, ease: "easeOut" }}
-									viewport={{ once: false }}
-									className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center"
-								>
+								<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
 									<p className="text-pretty text-sm text-muted-foreground/70">
 										Select at least two names to begin.
 									</p>
 									<Button variant="glass" onClick={() => scrollToSection("pick")}>
 										Go Back
 									</Button>
-								</motion.div>
+								</div>
 							)}
 						</Suspense>
 					</div>
@@ -201,21 +160,10 @@ export default function HomeRoute() {
 			>
 				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.6, ease: "easeOut" }}
-							viewport={{ once: false }}
-						>
+						<div>
 							<SectionHeading title="Your Rankings" subtitle="Final scores." />
-						</motion.div>
-						<motion.div
-							initial={{ opacity: 0, scale: 0.95 }}
-							whileInView={{ opacity: 1, scale: 1 }}
-							transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
-							viewport={{ once: false }}
-							className="w-full"
-						>
+						</div>
+						<div className="w-full">
 							<Suspense fallback={<Loading variant="skeleton" height={600} />}>
 								<ErrorBoundary context={errorContexts.analysisDashboard}>
 									<DashboardLazy
@@ -230,18 +178,12 @@ export default function HomeRoute() {
 									/>
 								</ErrorBoundary>
 							</Suspense>
-						</motion.div>
-						<motion.div
-							initial={{ opacity: 0, y: 20 }}
-							whileInView={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.6, ease: "easeOut", delay: 0.2 }}
-							viewport={{ once: false }}
-							className="mt-auto pt-8 flex justify-center"
-						>
+						</div>
+						<div className="mt-auto pt-8 flex justify-center">
 							<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
 								Start Over
 							</Button>
-						</motion.div>
+						</div>
 					</div>
 				</div>
 			</Section>

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -53,39 +53,76 @@ function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNam
 export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHeroSectionProps) {
 	return (
 		<div className="home-hero-wrapper w-full">
-			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden bg-background text-foreground px-6 text-center py-12 md:py-16 border-b border-border/40">
+			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden bg-background text-foreground px-6 text-center border-b border-border/40">
 				<motion.div
 					initial={{ opacity: 0, y: -20 }}
 					animate={{ opacity: 1, y: 0 }}
 					transition={{ duration: 0.6, ease: "easeOut" }}
-					className="flex flex-col items-center justify-center text-center max-w-4xl"
+					className="flex flex-col items-center justify-center text-center max-w-4xl gap-8 md:gap-12"
 				>
-					<p className={`mb-3 ${themeText.eyebrowWide}`}>My cat's name is</p>
-					<h1
-						className={`${themeText.heroDisplay} mb-6 tracking-tighter`}
-						style={{ fontSize: "clamp(2.5rem, 8vw, 6.5rem)", lineHeight: 1.05 }}
+					<motion.p
+						initial={{ opacity: 0, y: 10 }}
+						animate={{ opacity: 1, y: 0 }}
+						transition={{ delay: 0.1, duration: 0.5, ease: "easeOut" }}
+						className={`${themeText.eyebrowWide}`}
 					>
-						<HeroNameWords state={state} lockedNames={lockedNames} />
-					</h1>
+						My cat's name is
+					</motion.p>
+
+					<motion.div
+						initial={{ opacity: 0, scale: 0.9 }}
+						animate={{ opacity: 1, scale: 1 }}
+						transition={{ delay: 0.2, duration: 0.6, ease: "easeOut" }}
+					>
+						<h1
+							className={`${themeText.heroDisplay} tracking-tighter`}
+							style={{ fontSize: "clamp(2.5rem, 8vw, 6.5rem)", lineHeight: 1.05 }}
+						>
+							<HeroNameWords state={state} lockedNames={lockedNames} />
+						</h1>
+					</motion.div>
 
 					<motion.h2
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ delay: 0.2, duration: 0.6 }}
-						className="text-lg sm:text-xl md:text-2xl font-bold uppercase tracking-tight bg-gradient-to-r from-stardust via-hot-pink to-accent bg-clip-text text-transparent mb-6 text-center max-w-2xl px-4"
+						initial={{ opacity: 0, y: 10 }}
+						animate={{ opacity: 1, y: 0 }}
+						transition={{ delay: 0.35, duration: 0.6, ease: "easeOut" }}
+						className="text-lg sm:text-xl md:text-2xl font-bold uppercase tracking-tight bg-gradient-to-r from-stardust via-hot-pink to-accent bg-clip-text text-transparent text-center max-w-2xl px-4"
 						style={{ lineHeight: 1.2 }}
 					>
 						Run a tournament, gather opinions, and find the name that fits.
 					</motion.h2>
 
 					<motion.div
-						initial={{ opacity: 0, scale: 0.95 }}
-						animate={{ opacity: 1, scale: 1 }}
-						transition={{ delay: 0.4, duration: 0.4 }}
+						initial={{ opacity: 0, y: 20, scale: 0.95 }}
+						animate={{ opacity: 1, y: 0, scale: 1 }}
+						transition={{ delay: 0.5, duration: 0.5, ease: "easeOut" }}
+						className="mt-6"
 					>
 						<Button variant="glass" size="lg" onClick={onStartPicking}>
 							Narrow It Down
 						</Button>
+					</motion.div>
+
+					<motion.div
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 0.6 }}
+						transition={{ delay: 0.7, duration: 1, ease: "easeOut" }}
+						className="mt-12 flex flex-col items-center gap-2 text-muted-foreground"
+					>
+						<motion.svg
+							width="20"
+							height="20"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							animate={{ y: [0, 8, 0] }}
+							transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+						>
+							<polyline points="12 3 12 12 19 5" />
+							<path d="M18 13H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2z" />
+						</motion.svg>
+						<span className="text-xs font-medium">Scroll to continue</span>
 					</motion.div>
 				</motion.div>
 			</section>

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -53,7 +53,7 @@ function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNam
 export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHeroSectionProps) {
 	return (
 		<div className="home-hero-wrapper w-full">
-			<section className="relative isolate flex min-h-[45dvh] sm:min-h-[50dvh] w-full flex-col items-center justify-center overflow-hidden bg-background text-foreground px-6 text-center py-12 md:py-16 border-b border-border/40">
+			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden bg-background text-foreground px-6 text-center py-12 md:py-16 border-b border-border/40">
 				<motion.div
 					initial={{ opacity: 0, y: -20 }}
 					animate={{ opacity: 1, y: 0 }}

--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -90,8 +90,18 @@ export function NameSelector() {
 		...namesQueryOptions(isAdmin),
 		retry: 2,
 	});
-	const names = namesQuery.data?.names ?? [];
-	const isLoading = namesQuery.isPending;
+
+	const sampleNames: NameItem[] = [
+		{ id: "1", name: "Luna", description: "Graceful and mysterious" },
+		{ id: "2", name: "Miso", description: "Sweet and playful" },
+		{ id: "3", name: "Pixel", description: "Tech-savvy and clever" },
+		{ id: "4", name: "Saffron", description: "Warm and spicy personality" },
+		{ id: "5", name: "Noodle", description: "Long and stretchy" },
+		{ id: "6", name: "Ziggy", description: "Bold and energetic" },
+		{ id: "7", name: "Whiskers", description: "Classic and timeless" },
+		{ id: "8", name: "Pepper", description: "Small but mighty" },
+	];
+
 	const error =
 		namesQuery.error instanceof Error
 			? namesQuery.error.message
@@ -99,6 +109,8 @@ export function NameSelector() {
 				? "Failed to load names"
 				: null;
 	const isSupabaseUnavailable = error === SUPABASE_UNAVAILABLE_MSG;
+	const names = isSupabaseUnavailable ? sampleNames : (namesQuery.data?.names ?? []);
+	const isLoading = namesQuery.isPending && !isSupabaseUnavailable;
 
 	const syncSelectionToStore = useCallback(
 		(nextSelectedIds: Set<IdType>) => {
@@ -440,24 +452,20 @@ export function NameSelector() {
 		);
 	}
 
-	if (error) {
+	if (error && !isSupabaseUnavailable) {
 		return (
 			<div className="mx-auto w-full">
 				<div className="flex flex-col items-center justify-center py-20">
 					<div className="flex max-w-xl flex-col items-center gap-4 rounded-[1.5rem] border border-white/10 bg-white/[0.03] px-6 py-8 text-center shadow-[0_18px_40px_rgba(2,8,18,0.16)] backdrop-blur-md">
 						<p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary/80">
-							Picker unavailable
+							Failed to load
 						</p>
 						<div className="space-y-2">
 							<p className="font-display text-2xl leading-[0.96] tracking-[-0.04em] text-white">
-								{isSupabaseUnavailable
-									? "Connect Supabase to load the name pool."
-									: "We couldn&apos;t load the current shortlist."}
+								We couldn&apos;t load the current shortlist.
 							</p>
 							<p className="text-sm leading-relaxed text-white/68">
-								{isSupabaseUnavailable
-									? "The UI is ready, but local data needs `VITE_SUPABASE_URL` and a publishable key before names can appear here."
-									: error}
+								{error}
 							</p>
 						</div>
 						<div className="flex flex-wrap items-center justify-center gap-3">
@@ -473,6 +481,13 @@ export function NameSelector() {
 
 	return (
 		<div className="mx-auto w-full">
+			{isSupabaseUnavailable && (
+				<div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-center">
+					<p className="text-sm text-amber-200">
+						📝 Using sample cat names — <span className="font-medium">connect Supabase to load your own</span>
+					</p>
+				</div>
+			)}
 			<div className="space-y-4 sm:space-y-6 mobile-nav-safe-bottom">
 				{isSwipeMode ? (
 					<>


### PR DESCRIPTION
## Summary
- Expanded all home sections (Hero, Pick, Bracket, Rankings) to fill the full viewport height (`min-h-[100dvh]`)
- Added Previous/Next navigation buttons to each section so users can scroll sequentially between sections
- Enhanced hero section animations with staggered motion entries and a bouncing scroll indicator
- Added sample cat names (Luna, Miso, Pixel, etc.) as fallback data when Supabase is unavailable, replacing the blocking error state
- When Supabase is unavailable, a non-blocking amber banner is shown instead of an error screen, and the picker remains functional with sample data

## Scope
- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level
- [ ] Low (refactor/docs/tests)
- [x] Medium (feature logic change)
- [ ] High (auth/data/security/infra)

## Validation
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Tests added/updated for behavior changes
- [ ] Manual QA steps documented below

## Manual QA
1. Open the home page — confirm the hero section fills the full screen height
2. Verify the animated scroll indicator appears at the bottom of the hero
3. Click "Narrow It Down" — confirm it scrolls to the Pick section, which also fills the full screen
4. Use the Previous/Next buttons on each section to navigate up and down sequentially
5. Disconnect Supabase (remove env vars) — confirm the Pick section shows sample names with an amber banner instead of an error screen
6. With Supabase connected, confirm real names load and the amber banner is absent

## Rollout + Revert Plan
- Rollout approach: Standard deploy; no data migrations required
- Revert command/path: Revert the commits touching `HomeRoute.tsx`, `HomeSections.tsx`, and `NameSelector.tsx`

## Related
- Any follow-up work: Consider persisting scroll position across page reloads; explore smooth scroll snapping between full-page sections


---

<a href="https://builder.io/app/projects/6d59236d12f94be08f40/immense-hole-jgfsnoqp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://6d59236d12f94be08f40-immense-hole-jgfsnoqp_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=6d59236d12f94be08f40&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 964`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6d59236d12f94be08f40</projectId>-->
<!--<branchName>immense-hole-jgfsnoqp</branchName>-->