### PR TITLE
Restore colorful neon gradient background on hero

### DIFF
--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -53,7 +53,7 @@ function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNam
 export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHeroSectionProps) {
 	return (
 		<div className="home-hero-wrapper w-full">
-			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden bg-background text-foreground px-6 text-center border-b border-border/40">
+			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden text-foreground px-6 text-center border-b border-border/40">
 				<motion.div
 					initial={{ opacity: 0, y: -20 }}
 					animate={{ opacity: 1, y: 0 }}

--- a/src/shared/components/layout/LiquidGradientBackground.tsx
+++ b/src/shared/components/layout/LiquidGradientBackground.tsx
@@ -342,7 +342,6 @@ function useLiquidBackground(containerRef: React.RefObject<HTMLDivElement | null
 
 		const touchTexture = new TouchTexture();
 
-		/* Vibrant neon colors for more colorful effect */
 		const neonPurple = new THREE.Vector3(0.8, 0.0, 1.0);
 		const neonCyan = new THREE.Vector3(0.0, 1.0, 1.0);
 		const neonPink = new THREE.Vector3(1.0, 0.2, 0.8);

--- a/src/shared/components/layout/LiquidGradientBackground.tsx
+++ b/src/shared/components/layout/LiquidGradientBackground.tsx
@@ -330,7 +330,7 @@ function useLiquidBackground(containerRef: React.RefObject<HTMLDivElement | null
 		camera.position.z = 50;
 
 		const scene = new THREE.Scene();
-		scene.background = new THREE.Color(0x12100d);
+		scene.background = new THREE.Color(0x0a0a1a);
 
 		const timer = new THREE.Timer();
 
@@ -342,29 +342,33 @@ function useLiquidBackground(containerRef: React.RefObject<HTMLDivElement | null
 
 		const touchTexture = new TouchTexture();
 
-		/* Warm terracotta + ink brown — matches tokens.css palette */
-		const terracotta = new THREE.Vector3(0.78, 0.48, 0.36);
-		const warmInk = new THREE.Vector3(0.09, 0.07, 0.05);
+		/* Vibrant neon colors for more colorful effect */
+		const neonPurple = new THREE.Vector3(0.8, 0.0, 1.0);
+		const neonCyan = new THREE.Vector3(0.0, 1.0, 1.0);
+		const neonPink = new THREE.Vector3(1.0, 0.2, 0.8);
+		const neonGreen = new THREE.Vector3(0.0, 1.0, 0.4);
+		const neonOrange = new THREE.Vector3(1.0, 0.5, 0.0);
+		const neonBlue = new THREE.Vector3(0.2, 0.4, 1.0);
 
 		const uniforms: Uniforms = {
 			uTime: { value: 0 },
 			uResolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
-			uColor1: { value: terracotta.clone() },
-			uColor2: { value: warmInk.clone() },
-			uColor3: { value: terracotta.clone() },
-			uColor4: { value: warmInk.clone() },
-			uColor5: { value: terracotta.clone() },
-			uColor6: { value: warmInk.clone() },
-			uSpeed: { value: 0.65 }, // Reduced from 1.35
-			uIntensity: { value: 0.85 }, // Reduced from 1.55
+			uColor1: { value: neonPurple.clone() },
+			uColor2: { value: neonCyan.clone() },
+			uColor3: { value: neonPink.clone() },
+			uColor4: { value: neonGreen.clone() },
+			uColor5: { value: neonOrange.clone() },
+			uColor6: { value: neonBlue.clone() },
+			uSpeed: { value: 0.85 },
+			uIntensity: { value: 1.1 },
 			uTouchTexture: { value: touchTexture.texture },
-			uGrainIntensity: { value: 0.08 }, // Reduced from 0.11
+			uGrainIntensity: { value: 0.06 },
 			uZoom: { value: 1.0 },
-			uDarkNavy: { value: warmInk.clone() },
-			uGradientSize: { value: 0.45 },
+			uDarkNavy: { value: new THREE.Vector3(0.05, 0.05, 0.15) },
+			uGradientSize: { value: 0.5 },
 			uGradientCount: { value: 12.0 },
-			uColor1Weight: { value: 0.3 }, // Reduced from 0.5
-			uColor2Weight: { value: 1.8 },
+			uColor1Weight: { value: 0.6 },
+			uColor2Weight: { value: 0.6 },
 		};
 
 		const viewSize = getViewSize();


### PR DESCRIPTION
## Summary
- Replaced the warm terracotta/ink-brown color palette in the liquid gradient background with vibrant neon colors (purple, cyan, pink, green, orange, blue)
- Updated the Three.js scene background from a dark warm tone (`#12100d`) to a deep dark navy (`#0a0a1a`) to complement the neon palette
- Increased animation speed (`0.65 → 0.85`) and intensity (`0.85 → 1.1`) for a more dynamic effect
- Balanced color weights (`uColor1Weight`/`uColor2Weight`) so all six neon colors contribute more evenly
- Removed the `bg-background` class from the hero section so the animated gradient background shows through on the first visible panel

## Scope
- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level
- [x] Low (refactor/docs/tests)
- [ ] Medium (feature logic change)
- [ ] High (auth/data/security/infra)

## Validation
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Tests added/updated for behavior changes
- [ ] Manual QA steps documented below

## Manual QA
1. Open the app in a browser and navigate to the home page
2. Verify the hero section displays a colorful neon liquid gradient background (purple, cyan, pink, green, orange, blue tones) instead of the previous warm brown palette
3. Move the mouse over the hero section and confirm the gradient reacts to cursor position
4. Scroll past the hero and confirm no visual regressions on subsequent sections

## Rollout + Revert Plan
- Rollout approach: Standard deploy — purely visual/cosmetic change with no data or auth impact
- Revert command/path: Revert the changes in `LiquidGradientBackground.tsx` and restore `bg-background` class in `HomeSections.tsx`

## Related
- Issue/Task: User request to restore the colorful, mouse-reactive background to the hero section


---

<a href="https://builder.io/app/projects/db0783306cb144d8882b/empty-prize-amvcf6iy"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://db0783306cb144d8882b-empty-prize-amvcf6iy_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=db0783306cb144d8882b&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 968`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db0783306cb144d8882b</projectId>-->
<!--<branchName>empty-prize-amvcf6iy</branchName>-->