### PR TITLE
Unify motion constants and clean up UI clutter

### DIFF
--- a/src/app/components/AppBootScreen.tsx
+++ b/src/app/components/AppBootScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { SpinnerCircle } from "@/shared/components/layout/Feedback/Loading";
 import { themeText } from "@/shared/lib/themeClasses";
+import { TIMING } from "@/shared/lib/constants";
 import useAppStore from "@/store/appStore";
 
 const LOADING_PREVIEW = "/assets/images/loading-preview.png";
@@ -33,8 +34,8 @@ export function AppBootScreen({
 			setTimeout(() => {
 				setNameIdx((i) => (i + 1) % CAT_NAMES.length);
 				setNameVisible(true);
-			}, 320);
-		}, 1500);
+			}, TIMING.MOTION_FAST * 1000);
+		}, TIMING.MOTION_CYCLE);
 		return () => clearInterval(id);
 	}, [shouldRender]);
 
@@ -77,7 +78,7 @@ export function AppBootScreen({
 						lineHeight: 0.88,
 						letterSpacing: "-0.045em",
 						opacity: nameVisible ? 1 : 0,
-						transition: "opacity 0.3s ease",
+						transition: `opacity ${TIMING.MOTION_FAST}s ${TIMING.MOTION_EASING}`,
 					}}
 					aria-live="polite"
 					aria-atomic="true"

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -6,7 +6,6 @@ import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
 import { themeText } from "@/shared/lib/themeClasses";
 import { TIMING } from "@/shared/lib/constants";
-import { motion } from "framer-motion";
 import type { NameItem, RatingData } from "@/shared/types";
 
 type HomeHeroState = "loading" | "ready" | "error";

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -5,6 +5,8 @@ import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
 import { themeText } from "@/shared/lib/themeClasses";
+import { TIMING } from "@/shared/lib/constants";
+import { motion } from "framer-motion";
 import type { NameItem, RatingData } from "@/shared/types";
 
 type HomeHeroState = "loading" | "ready" | "error";
@@ -63,7 +65,7 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 					<motion.p
 						initial={{ opacity: 0, y: 10 }}
 						animate={{ opacity: 1, y: 0 }}
-						transition={{ delay: 0.1, duration: 0.5, ease: "easeOut" }}
+						transition={{ delay: 0.1, duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
 						className="text-sm font-medium uppercase tracking-wider text-muted-foreground/70"
 					>
 						Help me choose
@@ -72,7 +74,7 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 					<motion.div
 						initial={{ opacity: 0, scale: 0.9 }}
 						animate={{ opacity: 1, scale: 1 }}
-						transition={{ delay: 0.2, duration: 0.6, ease: "easeOut" }}
+						transition={{ delay: 0.2, duration: TIMING.MOTION_SLOW, ease: TIMING.MOTION_EASING }}
 					>
 						<h1
 							className={`${themeText.heroDisplay} tracking-tighter`}
@@ -85,7 +87,7 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 					<motion.h2
 						initial={{ opacity: 0, y: 10 }}
 						animate={{ opacity: 1, y: 0 }}
-						transition={{ delay: 0.35, duration: 0.6, ease: "easeOut" }}
+						transition={{ delay: 0.35, duration: TIMING.MOTION_SLOW, ease: TIMING.MOTION_EASING }}
 						className="text-lg sm:text-xl md:text-2xl font-semibold tracking-tight text-foreground/85 text-center max-w-2xl px-4"
 						style={{ lineHeight: 1.4 }}
 					>
@@ -95,7 +97,7 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 					<motion.div
 						initial={{ opacity: 0, y: 20, scale: 0.95 }}
 						animate={{ opacity: 1, y: 0, scale: 1 }}
-						transition={{ delay: 0.5, duration: 0.5, ease: "easeOut" }}
+						transition={{ delay: 0.5, duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
 						className="mt-6"
 					>
 						<Button variant="glass" size="lg" onClick={onStartPicking}>

--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -477,10 +477,13 @@ export function NameSelector() {
 	return (
 		<div className="mx-auto w-full">
 			{isSupabaseUnavailable && (
-				<div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-center">
-					<p className="text-sm text-amber-200">
-						📝 Using sample cat names —{" "}
-						<span className="font-medium">connect Supabase to load your own</span>
+				<div className="mb-6 rounded-lg border border-amber-500/40 bg-gradient-to-r from-amber-500/15 to-orange-500/10 px-5 py-4 backdrop-blur-sm">
+					<p className="flex items-start gap-3 text-sm">
+						<span className="mt-0.5 flex-shrink-0 text-lg">⚡</span>
+						<span>
+							<span className="text-amber-100 font-medium">Demo mode:</span>{" "}
+							<span className="text-amber-50">Connect Supabase to use your own names</span>
+						</span>
 					</p>
 				</div>
 			)}

--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -476,17 +476,6 @@ export function NameSelector() {
 
 	return (
 		<div className="mx-auto w-full">
-			{isSupabaseUnavailable && (
-				<div className="mb-6 rounded-lg border border-amber-500/40 bg-gradient-to-r from-amber-500/15 to-orange-500/10 px-5 py-4 backdrop-blur-sm">
-					<p className="flex items-start gap-3 text-sm">
-						<span className="mt-0.5 flex-shrink-0 text-lg">⚡</span>
-						<span>
-							<span className="text-amber-100 font-medium">Demo mode:</span>{" "}
-							<span className="text-amber-50">Connect Supabase to use your own names</span>
-						</span>
-					</p>
-				</div>
-			)}
 			<div className="space-y-4 sm:space-y-6 mobile-nav-safe-bottom">
 				{isSwipeMode ? (
 					<>

--- a/src/features/tournament/components/name-selector/nameSelectorUtils.ts
+++ b/src/features/tournament/components/name-selector/nameSelectorUtils.ts
@@ -12,7 +12,7 @@ export const getCardStyles = (isSelected: boolean, isLocked: boolean) => {
 
 // Name overlay styles utility
 export const getNameOverlayClasses = (variant: "grid" | "swipe") => {
-	const baseClasses = "absolute inset-0 flex flex-col items-center justify-end pointer-events-none";
+	const baseClasses = "absolute inset-0 flex flex-col items-center justify-center pointer-events-none";
 	const gridClasses =
 		"p-4 sm:p-5 bg-gradient-to-t from-slate-950/95 via-slate-950/55 to-transparent text-center";
 	const swipeClasses =

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -75,6 +75,13 @@ export const TIMING = {
 	RIPPLE_ANIMATION_DURATION_MS: 400,
 	VOTE_COOLDOWN_MS: 500,
 	TOURNAMENT_INIT_DELAY_MS: 16, // One frame for requestAnimationFrame
+
+	// Unified motion language: startup + entrance animations
+	MOTION_FAST: 0.3, // Quick state changes (icon swap, fade)
+	MOTION_NORMAL: 0.5, // Standard entrance (text, buttons)
+	MOTION_SLOW: 0.6, // Large elements (hero heading, CTA)
+	MOTION_CYCLE: 1500, // Name carousel, loop timing
+	MOTION_EASING: "easeOut", // Standard easing for entrances
 } as const;
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Added unified motion timing constants (`MOTION_FAST`, `MOTION_NORMAL`, `MOTION_SLOW`, `MOTION_CYCLE`, `MOTION_EASING`) to `TIMING` in `constants.ts` to establish a consistent animation language across the app
- Replaced all hardcoded animation durations and easing strings in `HomeSections.tsx` and `AppBootScreen.tsx` with the new shared constants
- Removed the "demo mode" Supabase banner (`⚡ Using sample cat names — connect Supabase to load your own`) from `NameSelector.tsx`
- Centered name overlay text vertically on name cards by changing `justify-end` to `justify-center` in `nameSelectorUtils.ts`

## Scope
- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level
- [x] Low (refactor/docs/tests)
- [ ] Medium (feature logic change)
- [ ] High (auth/data/security/infra)

## Validation
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Tests added/updated for behavior changes
- [ ] Manual QA steps documented below

## Manual QA
1. Open the app and observe the startup/boot screen — name carousel should animate smoothly with consistent timing
2. Navigate to the home page and verify hero section entrance animations feel cohesive (text, heading, CTA button)
3. Open the name selector in both grid and swipe modes — confirm name labels are vertically centered on cards
4. Verify the amber "demo mode / connect Supabase" banner is gone from the name selector view
5. Check that no visual regressions appear in loading or transition states

## Rollout + Revert Plan
- Rollout approach: Standard deploy — purely visual/animation changes with no data or auth impact
- Revert command/path: Revert this commit; no migrations or data changes to undo

## Related
- Any follow-up work: Consider applying `MOTION_*` constants to other animated components across the app for full consistency


---

<a href="https://builder.io/app/projects/db0783306cb144d8882b/coiled-lab-htbxkz4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://db0783306cb144d8882b-coiled-lab-htbxkz4c_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=db0783306cb144d8882b&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 971`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db0783306cb144d8882b</projectId>-->
<!--<branchName>coiled-lab-htbxkz4c</branchName>-->