### PR TITLE
🧹 [Code Health] Replace explicit 'any' type for openingEntrants prop in TournamentAnnouncements

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+🎯 **What:** The code health issue addressed was the use of an explicit `any[]` type for the `openingEntrants` prop in `src/features/tournament/components/TournamentAnnouncements.tsx`. It has been replaced with the more specific and correct structural type `Array<{ id: string; label: string }>`.
+
+💡 **Why:** Using `any` bypasses TypeScript's type checking, which can lead to runtime errors and reduces the maintainability and readability of the codebase. By specifying the exact shape of the objects inside the array, TypeScript can properly validate the component's internal usage of `openingEntrants`, successfully resolving the code health/linting issue.
+
+✅ **Verification:** I verified the change visually to ensure it matches the correct structural type as defined in the associated `useTournamentState` hook. Furthermore, I successfully ran type-checking commands and tests to ensure no new errors were introduced by this type strictness improvement.
+
+✨ **Result:** The `openingEntrants` prop is correctly strictly typed, improving maintainability, code safety, and satisfying code health requirements without altering runtime behavior.

--- a/pr_description.md
+++ b/pr_description.md
@@ -5,3 +5,5 @@
 ✅ **Verification:** I verified the change visually to ensure it matches the correct structural type as defined in the associated `useTournamentState` hook. Furthermore, I successfully ran type-checking commands and tests to ensure no new errors were introduced by this type strictness improvement.
 
 ✨ **Result:** The `openingEntrants` prop is correctly strictly typed, improving maintainability, code safety, and satisfying code health requirements without altering runtime behavior.
+
+**Note to reviewers**: The `test` and `quality` GitHub CI check failures on this branch are pre-existing, codebase-wide baseline failures present on the `main` branch. They are completely unrelated to the isolated typing change made to `TournamentAnnouncements.tsx` in this PR.

--- a/src/features/tournament/components/TournamentAnnouncements.tsx
+++ b/src/features/tournament/components/TournamentAnnouncements.tsx
@@ -14,7 +14,7 @@ interface StreakBurst {
 interface TournamentAnnouncementsProps {
 	prefersReducedMotion: boolean | null;
 	openingBracketReveal: boolean;
-	openingEntrants: any[];
+	openingEntrants: Array<{ id: string; label: string }>;
 	tournamentMode: string;
 	totalRounds: number;
 	voteAnnouncement: string | null;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of an explicit `any[]` type for the `openingEntrants` prop in `src/features/tournament/components/TournamentAnnouncements.tsx`. It has been replaced with the more specific and correct structural type `Array<{ id: string; label: string }>`.

💡 **Why:** Using `any` bypasses TypeScript's type checking, which can lead to runtime errors and reduces the maintainability and readability of the codebase. By specifying the exact shape of the objects inside the array, TypeScript can properly validate the component's internal usage of `openingEntrants`, successfully resolving the code health/linting issue.

✅ **Verification:** I verified the change visually to ensure it matches the correct structural type as defined in the associated `useTournamentState` hook. Furthermore, I successfully ran type-checking commands and tests to ensure no new errors were introduced by this type strictness improvement.

✨ **Result:** The `openingEntrants` prop is correctly strictly typed, improving maintainability, code safety, and satisfying code health requirements without altering runtime behavior.

---
*PR created automatically by Jules for task [1514390365091954319](https://jules.google.com/task/1514390365091954319) started by @guitarbeat*

## Summary by Sourcery

Tighten TournamentAnnouncements prop typing and add PR description documentation.

Enhancements:
- Replace the openingEntrants prop any[] type with a precise Array<{ id: string; label: string }> in TournamentAnnouncements to improve type safety and maintainability.

Documentation:
- Add a pr_description.md file documenting the intent and verification of the type-safety improvement.