### PR TITLE
🧪 Add tests for telemetry seam

### DIFF
--- a/src/shared/services/telemetrySeam.test.ts
+++ b/src/shared/services/telemetrySeam.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type TelemetryAdapter,
+	getTelemetryAdapter,
+	registerTelemetryAdapter,
+} from "./telemetrySeam";
+
+describe("telemetrySeam", () => {
+	let originalAdapter: TelemetryAdapter;
+
+	beforeEach(() => {
+		originalAdapter = getTelemetryAdapter();
+	});
+
+	afterEach(() => {
+		registerTelemetryAdapter(originalAdapter);
+		vi.restoreAllMocks();
+	});
+
+	describe("ConsoleTelemetryAdapter (default adapter)", () => {
+		it("should capture exception and log to console.error", () => {
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const adapter = getTelemetryAdapter();
+			const error = new Error("Test exception");
+			const tags = { tag1: "val1" };
+			const extra = { extra1: "val2" };
+
+			adapter.captureException(error, "TestContext", tags, extra);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				"🔴 [Telemetry Exception] Context:",
+				"TestContext",
+				error,
+				"Tags:",
+				tags,
+				"Extra:",
+				extra,
+			);
+		});
+
+		it("should log error and log to console.error", () => {
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const adapter = getTelemetryAdapter();
+			const formattedError = { type: "TEST_TYPE", userMessage: "Test user message" };
+
+			adapter.logError(formattedError, "TestContext");
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				"🔴 [Telemetry Error] [TEST_TYPE] Context: TestContext. Msg: Test user message",
+			);
+		});
+	});
+
+	describe("Adapter Management", () => {
+		it("should allow registering and retrieving a custom adapter", () => {
+			const customAdapter: TelemetryAdapter = {
+				captureException: vi.fn(),
+				logError: vi.fn(),
+			};
+
+			registerTelemetryAdapter(customAdapter);
+
+			const activeAdapter = getTelemetryAdapter();
+			expect(activeAdapter).toBe(customAdapter);
+
+			// Verify it's actually the one we set by calling a method
+			const error = new Error("Custom error");
+			activeAdapter.captureException(error, "CustomContext");
+			expect(customAdapter.captureException).toHaveBeenCalledWith(error, "CustomContext");
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `telemetrySeam.ts` file lacked unit tests, meaning the state management for the active telemetry adapter and the default console adapter behavior were completely unverified. This PR adds a comprehensive test suite for this module.

📊 **Coverage:** What scenarios are now tested
- Validates the default `ConsoleTelemetryAdapter` correctly logs to `console.error` for both `captureException` and `logError`.
- Verifies that `registerTelemetryAdapter` successfully updates the internal adapter state.
- Ensures `getTelemetryAdapter` correctly returns the newly registered adapter.
- Confirms the active adapter is the one used when its methods are invoked.

✨ **Result:** The improvement in test coverage
We now have full coverage for the telemetry seam, ensuring that custom adapters can be reliably registered and retrieved, and that the default console fallback behaves exactly as expected without regressions during future refactors.

---
*PR created automatically by Jules for task [8307759889719017468](https://jules.google.com/task/8307759889719017468) started by @guitarbeat*

## Summary by Sourcery

Add unit test coverage for the telemetry seam service, validating adapter registration and default console behavior.

Tests:
- Add tests for the default ConsoleTelemetryAdapter logging behavior for captureException and logError.
- Verify that registering a telemetry adapter updates the active adapter and getTelemetryAdapter returns it.