### PR TITLE
🧹 [Code Health] Remove stale @ts-expect-error overrides in ratingService

### DIFF
--- a/src/shared/services/supabase/ratingService.ts
+++ b/src/shared/services/supabase/ratingService.ts
@@ -77,7 +77,6 @@ export const ratingsAPI = {
 		winnerSide,
 	}: ApplyTournamentMatchParams) => {
 		return withSupabaseOrThrow(async (client) => {
-			// @ts-expect-error - apply_tournament_match_elo is a custom RPC not yet reflected in generated types
 			const { data, error } = await client.rpc("apply_tournament_match_elo", {
 				p_user_name: userName.trim(),
 				p_left_name_ids: leftNameIds,
@@ -130,7 +129,6 @@ export const ratingsAPI = {
 		}
 
 		return withSupabaseOrThrow(async (client) => {
-			// @ts-expect-error - save_user_ratings is a custom RPC not yet reflected in generated types
 			const { data, error } = await client.rpc("save_user_ratings", {
 				p_user_name: userId,
 				p_ratings: ratingsList,


### PR DESCRIPTION
🎯 **What:** Removed unnecessary `@ts-expect-error` directives above Supabase `client.rpc` calls in `ratingService.ts`.
💡 **Why:** The Supabase generated types (`src/integrations/supabase/types.ts`) now correctly include definitions for `apply_tournament_match_elo` and `save_user_ratings`. The `@ts-expect-error` overrides are stale and suppress valid type-checking, reducing code safety. Removing them aligns the code with the current schema.
✅ **Verification:** Verified that `pnpm run lint:types` passes cleanly, confirming the generated types match the arguments being passed. Also ran `pnpm test run src/shared/services/supabase/ratingService.test.ts` to ensure no functionality is broken.
✨ **Result:** Improved maintainability by relying on generated types rather than error suppression, preventing future silent regressions if the RPC signatures change.

---
*PR created automatically by Jules for task [14283970275156849781](https://jules.google.com/task/14283970275156849781) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Clean up ratingService RPC calls by removing obsolete @ts-expect-error directives now covered by Supabase generated types.