### PR TITLE
🧹 refactor: replace inline browser checks with IS_BROWSER constant

### DIFF
--- a/src/shared/services/supabase/runtime.ts
+++ b/src/shared/services/supabase/runtime.ts
@@ -3,6 +3,7 @@ import { QueryClient } from "@tanstack/react-query";
 import type { Database } from "@/integrations/supabase/types";
 import { STORAGE_KEYS } from "@/shared/lib/constants";
 import { getStorageString, isStorageAvailable } from "@/shared/lib/storage";
+import { IS_BROWSER } from "@/store/appStore.shared";
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
@@ -39,7 +40,7 @@ export function shouldWarnMissingSupabaseCredentials(hostname: string): boolean 
 
 function getCurrentHostname(): string {
 	try {
-		return typeof window === "undefined" ? "" : window.location.hostname;
+		return IS_BROWSER ? window.location.hostname : "";
 	} catch {
 		return "";
 	}
@@ -63,8 +64,9 @@ const getSupabaseCredentials = (): { url: string; key: string } | null => {
 	return { url, key };
 };
 
-let supabaseInstance: SupabaseClient<Database> | null =
-	typeof window === "undefined" ? null : (window.__supabaseClient ?? null);
+let supabaseInstance: SupabaseClient<Database> | null = IS_BROWSER
+	? (window.__supabaseClient ?? null)
+	: null;
 let initializationPromise: Promise<SupabaseClient<Database> | null> | null = null;
 
 const createSupabaseClient = async (): Promise<SupabaseClient<Database> | null> => {
@@ -111,7 +113,7 @@ const createSupabaseClient = async (): Promise<SupabaseClient<Database> | null> 
 			db: { schema: "public" },
 		});
 
-		if (typeof window !== "undefined") {
+		if (IS_BROWSER) {
 			window.__supabaseClient = client;
 		}
 		return client;


### PR DESCRIPTION
🎯 **What:** Replaced inline `typeof window === "undefined"` and `typeof window !== "undefined"` checks with the centralized `IS_BROWSER` constant imported from `@/store/appStore.shared`.
💡 **Why:** This improves codebase consistency and readability by using a single, unified abstraction for environment detection instead of scattering raw string comparisons throughout the module.
✅ **Verification:** Visually verified via `git diff`, formatted using Biome, and confirmed that the full `pnpm test run` test suite passes without any new regressions.
✨ **Result:** A cleaner, more maintainable Supabase runtime module that strictly adheres to the project's centralized browser-detection convention.

---
*PR created automatically by Jules for task [3437535009471523091](https://jules.google.com/task/3437535009471523091) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Replace inline window existence checks in the Supabase runtime module with the shared IS_BROWSER constant for consistent environment detection.