### PR TITLE
fix: remove @ts-expect-error in Card component by adding disabled and type to CardProps

### DIFF
--- a/src/shared/components/layout/Card/Card.tsx
+++ b/src/shared/components/layout/Card/Card.tsx
@@ -490,6 +490,7 @@ const CardNameBase = memo(function CardName({
 					className,
 				)}
 				onClick={isInteractive ? handleInteraction : undefined}
+				// @ts-expect-error - Card props might not fully match HTML attributes
 				disabled={isInteractive ? disabled : undefined}
 				aria-pressed={isInteractive ? isSelected : undefined}
 				aria-label={getAriaLabel()}

--- a/src/shared/components/layout/Card/Card.tsx
+++ b/src/shared/components/layout/Card/Card.tsx
@@ -104,7 +104,7 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	interactive?: boolean;
 	enableTilt?: boolean;
 	disabled?: boolean;
-	type?: "button" | "submit" | "reset" | undefined;
+	type?: "button" | "submit" | "reset";
 }
 
 const CardBase = memo(
@@ -490,7 +490,6 @@ const CardNameBase = memo(function CardName({
 					className,
 				)}
 				onClick={isInteractive ? handleInteraction : undefined}
-				// @ts-expect-error - Card props might not fully match HTML attributes
 				disabled={isInteractive ? disabled : undefined}
 				aria-pressed={isInteractive ? isSelected : undefined}
 				aria-label={getAriaLabel()}

--- a/src/shared/components/layout/Card/Card.tsx
+++ b/src/shared/components/layout/Card/Card.tsx
@@ -104,7 +104,7 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	interactive?: boolean;
 	enableTilt?: boolean;
 	disabled?: boolean;
-	type?: "button" | "submit" | "reset";
+	type?: "button" | "submit" | "reset" | undefined;
 }
 
 const CardBase = memo(

--- a/src/shared/components/layout/Card/Card.tsx
+++ b/src/shared/components/layout/Card/Card.tsx
@@ -103,6 +103,8 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	liquidGlass?: boolean | GlassConfig;
 	interactive?: boolean;
 	enableTilt?: boolean;
+	disabled?: boolean;
+	type?: "button" | "submit" | "reset";
 }
 
 const CardBase = memo(
@@ -488,7 +490,6 @@ const CardNameBase = memo(function CardName({
 					className,
 				)}
 				onClick={isInteractive ? handleInteraction : undefined}
-				// @ts-expect-error - Card props might not fully match HTML attributes
 				disabled={isInteractive ? disabled : undefined}
 				aria-pressed={isInteractive ? isSelected : undefined}
 				aria-label={getAriaLabel()}


### PR DESCRIPTION
🎯 **What:** Removed the `@ts-expect-error` comment on the `disabled` prop in `CardNameBase` within `src/shared/components/layout/Card/Card.tsx` and resolved the underlying TypeScript error.
💡 **Why:** The component expects `CardProps` which extends `React.HTMLAttributes<HTMLDivElement>`, so passing `disabled` or `type` throws TS errors. Instead of suppressing it with a comment, this explicitly adds `disabled` and `type` to `CardProps` so the types correctly match the runtime behavior where this acts as an interactive element. This improves typing robustness and codebase maintainability by avoiding ts-ignores.
✅ **Verification:** Verified that `pnpm exec tsc --noEmit` and `pnpm test run` pass successfully without errors.
✨ **Result:** A cleaner component interface that strictly conforms to React typings and avoids ignoring errors.

---
*PR created automatically by Jules for task [12353221707492167478](https://jules.google.com/task/12353221707492167478) started by @guitarbeat*