### PR TITLE
🧹 [code health improvement] Refactor supabase runtime to use strong types instead of @ts-expect-error

### DIFF
--- a/src/shared/services/supabase/runtime.ts
+++ b/src/shared/services/supabase/runtime.ts
@@ -145,6 +145,13 @@ const getSupabaseClient = async (retryCount = 0): Promise<SupabaseClient<Databas
 
 export const resolveSupabaseClient = async () => supabaseInstance ?? (await getSupabaseClient());
 
+
+type SupabaseClientWithHeaders = SupabaseClient<Database> & {
+	rest?: {
+		headers: Record<string, string | undefined>;
+	};
+};
+
 export const updateSupabaseUserContext = (
 	userName: string | null,
 	userId: string | null = null,
@@ -152,22 +159,20 @@ export const updateSupabaseUserContext = (
 	if (!supabaseInstance) {
 		return;
 	}
-	// @ts-expect-error - accessing internal property
-	if (supabaseInstance.rest?.headers) {
+
+	const client = supabaseInstance as SupabaseClientWithHeaders;
+
+	if (client.rest?.headers) {
 		if (userName) {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-name"] = userName;
+			client.rest.headers["x-user-name"] = userName;
 		} else {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-name"] = undefined;
+			client.rest.headers["x-user-name"] = undefined;
 		}
 
 		if (userId) {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-id"] = userId;
+			client.rest.headers["x-user-id"] = userId;
 		} else {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-id"] = undefined;
+			client.rest.headers["x-user-id"] = undefined;
 		}
 	}
 };


### PR DESCRIPTION
🎯 **What:** The codebase currently uses multiple `@ts-expect-error` annotations when accessing and modifying the internal `rest.headers` property of the `SupabaseClient` within the `updateSupabaseUserContext` function in `src/shared/services/supabase/runtime.ts`.

💡 **Why:** Relying on `@ts-expect-error` bypasses TypeScript's type-checking, reducing code safety and cluttering the code with suppression comments. By explicitly extending the `SupabaseClient` type with a locally defined `SupabaseClientWithHeaders` intersection type, we can tell the compiler exactly what shape to expect. This improves maintainability, readability, and eliminates compiler warning suppressions while remaining fully type-safe.

✅ **Verification:** 
- The refactored code correctly uses type casting to avoid modifying global types while ensuring local type safety.
- `pnpm run lint:types` passes successfully.
- Tests passed.
- Pre-commit code review resulted in `#Correct#`.

✨ **Result:** A cleaner `runtime.ts` file without type suppression comments and fully safe access to internal headers.

---
*PR created automatically by Jules for task [10758236443102648029](https://jules.google.com/task/10758236443102648029) started by @guitarbeat*