### PR TITLE
Deslop UI: remove clutter, refresh copy, extract NavbarModals

### DIFF
--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -64,7 +64,7 @@ export default function HomeRoute() {
 				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
 						<div>
-							<SectionHeading title="Pick Your Favorites" subtitle="Swipe or click to select names you love." />
+							<SectionHeading title="My Cat Needs a Name" subtitle="Pick your favorites. Let's see what wins." />
 						</div>
 						<div className="w-full">
 							<Suspense fallback={<Loading variant="skeleton" height={400} />}>
@@ -94,7 +94,7 @@ export default function HomeRoute() {
 				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
 						<div>
-							<SectionHeading title="Compare Names" subtitle="Vote on which name you prefer in each matchup." />
+							<SectionHeading title="But See How I Got There" subtitle="Head-to-head matchups to rank them all." />
 						</div>
 						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 							{tournament.names && tournament.names.length > 0 ? (

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -54,7 +54,7 @@ function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNam
 export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHeroSectionProps) {
 	return (
 		<div className="home-hero-wrapper w-full">
-			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden text-foreground px-6 text-center border-b border-border/40">
+			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden text-foreground px-6 text-center">
 				<motion.div
 					initial={{ opacity: 0, y: -20 }}
 					animate={{ opacity: 1, y: 0 }}

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -67,7 +67,7 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 						transition={{ delay: 0.1, duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
 						className="text-sm font-medium uppercase tracking-wider text-muted-foreground/70"
 					>
-						Help me choose
+						What should we name my cat?
 					</motion.p>
 
 					<motion.div
@@ -90,7 +90,7 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 						className="text-lg sm:text-xl md:text-2xl font-semibold tracking-tight text-foreground/85 text-center max-w-2xl px-4"
 						style={{ lineHeight: 1.4 }}
 					>
-						Vote on your favorite names and discover what your friends think too.
+						Pick your favorites and see which names score highest with your friends.
 					</motion.h2>
 
 					<motion.div

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -103,28 +103,6 @@ export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHero
 							Get Started
 						</Button>
 					</motion.div>
-
-					<motion.div
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 0.6 }}
-						transition={{ delay: 0.7, duration: 1, ease: "easeOut" }}
-						className="mt-12 flex flex-col items-center gap-2 text-muted-foreground"
-					>
-						<motion.svg
-							width="20"
-							height="20"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							animate={{ y: [0, 8, 0] }}
-							transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
-						>
-							<polyline points="12 3 12 12 19 5" />
-							<path d="M18 13H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2z" />
-						</motion.svg>
-						<span className="text-xs font-medium">Scroll to continue</span>
-					</motion.div>
 				</motion.div>
 			</section>
 		</div>

--- a/src/features/dashboard/components/analytics/Dashboard.tsx
+++ b/src/features/dashboard/components/analytics/Dashboard.tsx
@@ -92,74 +92,6 @@ function getQuickStats({
 	return [];
 }
 
-function DashboardEmptyState({
-	isLoggedIn,
-	onStartNew,
-}: {
-	isLoggedIn: boolean;
-	onStartNew?: () => void;
-}) {
-	return (
-		<Panel>
-			<SectionHeader
-				icon={BarChart3}
-				title="Nothing Ranked Yet"
-				subtitle={isLoggedIn ? "Run a bracket to start." : "Run a bracket to begin."}
-				action={
-					onStartNew ? (
-						<Button variant="outline" size="small" onClick={onStartNew}>
-							Pick Different Names
-						</Button>
-					) : undefined
-				}
-			/>
-			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-				<div className="group relative overflow-hidden rounded-xl border border-border/50 bg-gradient-to-br from-primary/5 to-accent/5 p-5 transition-all hover:border-primary/30 hover:shadow-sm">
-					<div className="absolute -top-8 -right-8 size-16 rounded-full bg-primary/5 blur-2xl" />
-					<div className="relative space-y-3">
-						<div className="flex items-center gap-2">
-							<div className="rounded-lg bg-primary/10 p-2">
-								<Target size={18} className="text-primary" />
-							</div>
-							<p className={`${themeText.eyebrowWide}`}>Personal Layer</p>
-						</div>
-						<p className="text-sm leading-relaxed text-muted-foreground/75">
-							Your personal ranking after completing the bracket tournament.
-						</p>
-					</div>
-				</div>
-				<div className="group relative overflow-hidden rounded-xl border border-border/50 bg-gradient-to-br from-accent/5 to-cyan-600/5 p-5 transition-all hover:border-accent/30 hover:shadow-sm">
-					<div className="absolute -top-8 -right-8 size-16 rounded-full bg-accent/5 blur-2xl" />
-					<div className="relative space-y-3">
-						<div className="flex items-center gap-2">
-							<div className="rounded-lg bg-accent/10 p-2">
-								<Users size={18} className="text-accent" />
-							</div>
-							<p className={`${themeText.eyebrowWide}`}>Community Layer</p>
-						</div>
-						<p className="text-sm leading-relaxed text-muted-foreground/75">
-							Aggregate rankings from all users across the community.
-						</p>
-					</div>
-				</div>
-				<div className="group relative overflow-hidden rounded-xl border border-border/50 bg-gradient-to-br from-yellow-600/5 to-orange-600/5 p-5 transition-all hover:border-yellow-600/30 hover:shadow-sm">
-					<div className="absolute -top-8 -right-8 size-16 rounded-full bg-yellow-600/5 blur-2xl" />
-					<div className="relative space-y-3">
-						<div className="flex items-center gap-2">
-							<div className="rounded-lg bg-yellow-600/10 p-2">
-								<Trophy size={18} className="text-yellow-600" />
-							</div>
-							<p className={`${themeText.eyebrowWide}`}>Leaderboard</p>
-						</div>
-						<p className="text-sm leading-relaxed text-muted-foreground/75">
-							Top performing names ranked by community votes and ratings.
-						</p>
-					</div>
-				</div>
-			</div>
-		</Panel>
-	);
-}
 
 function DashboardHeader({
 	isLoggedIn,
@@ -436,9 +368,6 @@ export function Dashboard({
 				userStats={userStats}
 			/>
 
-			{shouldShowDashboardPrimer && (
-				<DashboardEmptyState isLoggedIn={isLoggedIn} onStartNew={onStartNew} />
-			)}
 
 			{hasPersonalRatings && onUpdateRatings && (
 				<Panel>

--- a/src/features/tournament/components/name-selector/NameContent.tsx
+++ b/src/features/tournament/components/name-selector/NameContent.tsx
@@ -9,8 +9,8 @@ export const NameContent = ({
 }) => {
 	const isGrid = variant === "grid";
 	const nameClasses = isGrid
-		? "w-full break-words font-display text-2xl leading-[0.92] tracking-tight text-white sm:text-[2rem]"
-		: "w-full break-words font-display text-4xl leading-[0.92] tracking-tight text-white lg:text-5xl";
+		? "w-full break-words font-whimsical text-2xl leading-[0.92] tracking-tight text-white sm:text-[2rem]"
+		: "w-full break-words font-whimsical text-4xl leading-[0.92] tracking-tight text-white lg:text-5xl";
 
 	const pronunciationClasses = isGrid
 		? "text-[11px] font-semibold uppercase tracking-[0.22em] text-white/70"

--- a/src/shared/components/layout/AppLayout.tsx
+++ b/src/shared/components/layout/AppLayout.tsx
@@ -1,7 +1,6 @@
 import { lazy, type ReactNode, Suspense } from "react";
 import { shouldEnableAnalytics } from "@/app/analytics";
 import { PwaInstallPrompt } from "@/app/components/PwaInstallPrompt";
-import { ScrollToTopButton } from "@/shared/components/layout/Button";
 import { ErrorBoundary, ErrorComponent } from "@/shared/components/layout/Feedback/ErrorBoundary";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { OfflineIndicator } from "@/shared/components/layout/Feedback/OfflineIndicator";
@@ -91,8 +90,6 @@ export function AppLayout({ children }: AppLayoutProps) {
 							<Loading variant="spinner" text="Initializing Tournament..." />
 						</div>
 					)}
-
-					<ScrollToTopButton />
 				</main>
 			</div>
 		</ErrorBoundary>

--- a/src/shared/components/layout/FloatingNavbar.tsx
+++ b/src/shared/components/layout/FloatingNavbar.tsx
@@ -8,15 +8,14 @@ import {
 	Trophy,
 	User,
 } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/app/providers/Providers";
-import { Loading } from "@/shared/components/layout/Feedback/Loading";
-import { Modal } from "@/shared/components/layout/Modal";
 import {
 	DynamicIslandNav,
 	type DynamicIslandNavItem,
 } from "@/shared/components/ui/dynamic-island-nav";
+import { NavbarModals } from "@/shared/components/ui/NavbarModals";
 import { hapticNavTap, hapticTournamentStart } from "@/shared/lib/browser/haptics";
 import { cn } from "@/shared/lib/utils";
 import useAppStore from "@/store/appStore";
@@ -75,18 +74,6 @@ const keyToId: Record<NavSection, string> = {
 	tournament: "tournament",
 	analysis: "analysis",
 };
-
-const LazyProfileInner = lazy(() =>
-	import("@/shared/components/profile/ProfileInner").then((module) => ({
-		default: module.ProfileInner,
-	})),
-);
-
-const LazyNameSuggestion = lazy(() =>
-	import("@/features/tournament/components/NameSuggestion").then((module) => ({
-		default: module.NameSuggestion,
-	})),
-);
 
 export function FloatingNavbar() {
 	const appStore = useAppStore();
@@ -521,45 +508,22 @@ export function FloatingNavbar() {
 
 			<MobileBottomNav items={navItems} isVisible={shouldShow} />
 
-			{isProfileOpen && (
-				<Modal
-					title="Your Profile"
-					hideTitle={true}
-					open={isProfileOpen}
-					onClose={() => setIsProfileOpen(false)}
-					maxWidth="max-w-md"
-					description="Sign in to save your rankings."
-					originRect={profileOriginRect}
-				>
-					<Suspense fallback={<Loading variant="card-skeleton" height={260} />}>
-						<LazyProfileInner
-							onLogin={async (name) => {
-								const ok = await login({ name });
-								if (ok !== false) {
-									setIsProfileOpen(false);
-								}
-								return ok;
-							}}
-							onLogout={logout}
-						/>
-					</Suspense>
-				</Modal>
-			)}
-			{isSuggestOpen && (
-				<Modal
-					title="Suggest a Name"
-					hideTitle={true}
-					open={isSuggestOpen}
-					onClose={() => setIsSuggestOpen(false)}
-					maxWidth="max-w-md"
-					description="Suggest a cat name."
-					originRect={suggestOriginRect}
-				>
-					<Suspense fallback={<Loading variant="card-skeleton" height={260} />}>
-						<LazyNameSuggestion variant="modal" onClose={() => setIsSuggestOpen(false)} />
-					</Suspense>
-				</Modal>
-			)}
+			<NavbarModals
+				isProfileOpen={isProfileOpen}
+				isSuggestOpen={isSuggestOpen}
+				onProfileClose={() => setIsProfileOpen(false)}
+				onSuggestClose={() => setIsSuggestOpen(false)}
+				profileOriginRect={profileOriginRect}
+				suggestOriginRect={suggestOriginRect}
+				onLogin={async (name) => {
+					const ok = await login({ name });
+					if (ok !== false) {
+						setIsProfileOpen(false);
+					}
+					return ok;
+				}}
+				onLogout={logout}
+			/>
 		</>
 	);
 }

--- a/src/shared/components/layout/FloatingNavbar.tsx
+++ b/src/shared/components/layout/FloatingNavbar.tsx
@@ -358,7 +358,7 @@ export function FloatingNavbar() {
 			return `Start (${selectedCount})`;
 		}
 		if (activeSection === "analysis") {
-			return "Analyze";
+			return "Bracket";
 		}
 		if (activeSection === "tournament") {
 			return "Bracket";

--- a/src/shared/components/ui/NavbarModals.tsx
+++ b/src/shared/components/ui/NavbarModals.tsx
@@ -1,0 +1,72 @@
+import { lazy, Suspense } from "react";
+import { Modal } from "@/shared/components/layout/Modal";
+import { Loading } from "@/shared/components/layout/Feedback/Loading";
+
+const LazyProfileInner = lazy(() =>
+	import("@/shared/components/profile/ProfileInner").then((module) => ({
+		default: module.ProfileInner,
+	})),
+);
+
+const LazyNameSuggestion = lazy(() =>
+	import("@/features/tournament/components/NameSuggestion").then((module) => ({
+		default: module.NameSuggestion,
+	})),
+);
+
+interface NavbarModalsProps {
+	isProfileOpen: boolean;
+	isSuggestOpen: boolean;
+	onProfileClose: () => void;
+	onSuggestClose: () => void;
+	profileOriginRect: { x: number; y: number; width: number; height: number } | null;
+	suggestOriginRect: { x: number; y: number; width: number; height: number } | null;
+	onLogin: (name: string) => Promise<boolean | undefined>;
+	onLogout: () => void;
+}
+
+export function NavbarModals({
+	isProfileOpen,
+	isSuggestOpen,
+	onProfileClose,
+	onSuggestClose,
+	profileOriginRect,
+	suggestOriginRect,
+	onLogin,
+	onLogout,
+}: NavbarModalsProps) {
+	return (
+		<>
+			{isProfileOpen && (
+				<Modal
+					title="Your Profile"
+					hideTitle={true}
+					open={isProfileOpen}
+					onClose={onProfileClose}
+					maxWidth="max-w-md"
+					description="Sign in to save your rankings."
+					originRect={profileOriginRect}
+				>
+					<Suspense fallback={<Loading variant="card-skeleton" height={260} />}>
+						<LazyProfileInner onLogin={onLogin} onLogout={onLogout} />
+					</Suspense>
+				</Modal>
+			)}
+			{isSuggestOpen && (
+				<Modal
+					title="Suggest a Name"
+					hideTitle={true}
+					open={isSuggestOpen}
+					onClose={onSuggestClose}
+					maxWidth="max-w-md"
+					description="Suggest a cat name."
+					originRect={suggestOriginRect}
+				>
+					<Suspense fallback={<Loading variant="card-skeleton" height={260} />}>
+						<LazyNameSuggestion variant="modal" onClose={onSuggestClose} />
+					</Suspense>
+				</Modal>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
## Summary
- Updated hero and section copy to be cat-name-themed and friendlier ("What should we name my cat?", "My Cat Needs a Name", "But See How I Got There")
- Removed the animated "Scroll to continue" indicator and section border from the hero
- Removed the `DashboardEmptyState` primer panel (fake results placeholder) from the analytics dashboard
- Removed the `ScrollToTopButton` from `AppLayout`
- Extracted lazy-loaded profile and name suggestion modals from `FloatingNavbar` into a new `NavbarModals` component for cleaner separation
- Switched name card font from `font-display` to `font-whimsical` for a friendlier feel

## Scope
- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level
- [x] Low (refactor/docs/tests)
- [ ] Medium (feature logic change)
- [ ] High (auth/data/security/infra)

## Validation
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Tests added/updated for behavior changes
- [ ] Manual QA steps documented below

## Manual QA
1. Visit the home page — confirm hero reads "What should we name my cat?" with no section border and no scroll indicator
2. Scroll to the favorites section — confirm heading reads "My Cat Needs a Name"
3. Scroll to the bracket section — confirm heading reads "But See How I Got There"
4. Open the analytics/results dashboard with no rankings — confirm the empty-state primer panel is gone
5. Open the floating nav — confirm Profile and Suggest modals still open and function correctly
6. Check name cards in grid and list view — confirm font renders with the whimsical style
7. Confirm no scroll-to-top button appears anywhere in the layout

## Rollout + Revert Plan
- Rollout approach: Standard deploy; purely visual/copy changes with no data or auth impact
- Revert command/path: `git revert <commit>` or redeploy previous build

## Related
- Issue/Task: User-driven UI cleanup ("deslop") session
- Any follow-up work: Further copy refinement; audit remaining `font-display` usages if full font migration is intended


---

<a href="https://builder.io/app/projects/db0783306cb144d8882b/stealth-retreat-zaikkusr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://db0783306cb144d8882b-stealth-retreat-zaikkusr_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=db0783306cb144d8882b&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1002`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db0783306cb144d8882b</projectId>-->
<!--<branchName>stealth-retreat-zaikkusr</branchName>-->