### PR TITLE
Refactor home route into SectionFlow with MagneticNav

### DIFF
--- a/src/app/components/AppBootScreen.tsx
+++ b/src/app/components/AppBootScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { SpinnerCircle } from "@/shared/components/layout/Feedback/Loading";
-import { themeText } from "@/shared/lib/themeClasses";
 import { TIMING } from "@/shared/lib/constants";
+import { themeText } from "@/shared/lib/themeClasses";
 import useAppStore from "@/store/appStore";
 
 const LOADING_PREVIEW = "/assets/images/loading-preview.png";

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -2,27 +2,24 @@ import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useCallback, useEffect } from "react";
 import { errorContexts, routeComponents } from "@/app/appConfig";
 import { HomeHeroSection } from "@/app/routes/components/HomeSections";
+import { SectionFlow } from "@/shared/components/ui/SectionFlow";
 import { namesQueryOptions } from "@/shared/api/names/api";
-
-import Button from "@/shared/components/layout/Button";
 import { ErrorBoundary } from "@/shared/components/layout/Feedback/ErrorBoundary";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
-import { SectionNavigation } from "@/shared/components/layout/SectionNavigation";
 import { useSectionScroll } from "@/shared/hooks/useSectionScroll";
 import { getLockedNames } from "@/shared/lib/names/nameFilters";
 import useAppStore from "@/store/appStore";
 
 const LazyTournament = lazy(() => import("@/features/tournament/Tournament"));
-
 const TournamentFlow = routeComponents.TournamentFlow;
 const DashboardLazy = routeComponents.DashboardLazy;
 
 export default function HomeRoute() {
 	const { user, tournament, tournamentActions } = useAppStore();
 	const namesQuery = useQuery(namesQueryOptions(user.isAdmin));
-	const { scrollToSection, scheduleSectionScroll, clearPendingScroll } = useSectionScroll();
+	const { clearPendingScroll } = useSectionScroll();
 
 	const hasNamesData = typeof namesQuery.data !== "undefined";
 	const heroState =
@@ -34,10 +31,6 @@ export default function HomeRoute() {
 	const names = namesQuery.data?.names ?? [];
 	const lockedNames = heroState === "ready" ? getLockedNames(names) : [];
 
-	const scheduleAnalysisScroll = useCallback(() => {
-		scheduleSectionScroll("analysis");
-	}, [scheduleSectionScroll]);
-
 	const handleStartNewTournament = useCallback(() => {
 		clearPendingScroll();
 		tournamentActions.resetTournament();
@@ -46,133 +39,113 @@ export default function HomeRoute() {
 	useEffect(() => clearPendingScroll, [clearPendingScroll]);
 
 	return (
-		<>
-			<HomeHeroSection
-				state={heroState}
-				lockedNames={lockedNames}
-				onStartPicking={() => scrollToSection("pick")}
-			/>
-
-			<Section
-				id="pick"
-				variant="minimal"
-				padding="comfortable"
-				maxWidth="xl"
-				separator={true}
-				fullpage={true}
-			>
-				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<div>
-							<SectionHeading title="My Cat Needs a Name" subtitle="Pick your favorites. Let's see what wins." />
-						</div>
-						<div className="w-full">
-							<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-								<TournamentFlow />
-							</Suspense>
-						</div>
-						<div className="mt-auto pt-8 flex justify-center gap-4">
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("")}>
-								← Back
-							</Button>
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								Compare →
-							</Button>
-						</div>
+		<SectionFlow
+			sections={{
+				hero: (
+					<div className="home-hero-wrapper w-full">
+						<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden text-foreground px-6 text-center">
+							<HomeHeroSection state={heroState} lockedNames={lockedNames} />
+						</section>
 					</div>
-				</div>
-			</Section>
-
-			<Section
-				id="tournament"
-				variant="minimal"
-				padding="comfortable"
-				maxWidth="2xl"
-				separator={true}
-				fullpage={true}
-			>
-				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<div>
-							<SectionHeading title="But See How I Got There" subtitle="Head-to-head matchups to rank them all." />
-						</div>
-						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-							{tournament.names && tournament.names.length > 0 ? (
-								<>
-									<div className="w-full">
-										<LazyTournament
-											names={tournament.names}
-											existingRatings={tournament.ratings}
-											onComplete={(ratings) => {
-												tournamentActions.completeTournament(ratings);
-												scheduleAnalysisScroll();
-											}}
-										/>
-									</div>
-									<div className="mt-auto pt-8 flex justify-center gap-4">
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-											← Back
-										</Button>
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
-											See Results →
-										</Button>
-									</div>
-								</>
-							) : (
-								<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
-									<p className="text-pretty text-sm text-muted-foreground/70">
-										Pick at least 2 names to start comparing them.
-									</p>
-									<Button variant="glass" onClick={() => scrollToSection("pick")}>
-										← Back
-									</Button>
+				),
+				pick: (
+					<Section
+						id="pick"
+						variant="minimal"
+						padding="comfortable"
+						maxWidth="xl"
+						separator={true}
+						fullpage={true}
+					>
+						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+								<SectionHeading
+									title="My Cat Needs a Name"
+									subtitle="Pick your favorites. Let's see what wins."
+								/>
+								<div className="w-full">
+									<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+										<TournamentFlow />
+									</Suspense>
 								</div>
-							)}
-						</Suspense>
-					</div>
-				</div>
-			</Section>
-
-			<Section
-				id="analysis"
-				variant="minimal"
-				padding="comfortable"
-				maxWidth="2xl"
-				separator={true}
-				fullpage={true}
-			>
-				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<div>
-							<SectionHeading title="Results" subtitle="See how all the names ranked." />
+							</div>
 						</div>
-						<div className="w-full">
-							<Suspense fallback={<Loading variant="skeleton" height={600} />}>
-								<ErrorBoundary context={errorContexts.analysisDashboard}>
-									<DashboardLazy
-										personalRatings={tournament.ratings}
-										currentTournamentNames={tournament.names ?? undefined}
-										onStartNew={handleStartNewTournament}
-										onUpdateRatings={tournamentActions.setRatings}
-										userName={user.name ?? ""}
-										isAdmin={user.isAdmin}
-										isLoggedIn={user.isLoggedIn}
-										avatarUrl={user.avatarUrl}
-									/>
-								</ErrorBoundary>
-							</Suspense>
+					</Section>
+				),
+				tournament: (
+					<Section
+						id="tournament"
+						variant="minimal"
+						padding="comfortable"
+						maxWidth="2xl"
+						separator={true}
+						fullpage={true}
+					>
+						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+								<SectionHeading
+									title="But See How I Got There"
+									subtitle="Head-to-head matchups to rank them all."
+								/>
+								<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+									{tournament.names && tournament.names.length > 0 ? (
+										<div className="w-full">
+											<LazyTournament
+												names={tournament.names}
+												existingRatings={tournament.ratings}
+												onComplete={(ratings) => {
+													tournamentActions.completeTournament(ratings);
+												}}
+											/>
+										</div>
+									) : (
+										<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
+											<p className="text-pretty text-sm text-muted-foreground/70">
+												Pick at least 2 names to start comparing them.
+											</p>
+										</div>
+									)}
+								</Suspense>
+							</div>
 						</div>
-						<div className="mt-auto pt-8 flex justify-center gap-4">
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								← Back
-							</Button>
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-								Pick Different Names
-							</Button>
+					</Section>
+				),
+				analysis: (
+					<Section
+						id="analysis"
+						variant="minimal"
+						padding="comfortable"
+						maxWidth="2xl"
+						separator={true}
+						fullpage={true}
+					>
+						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+								<SectionHeading
+									title="Results"
+									subtitle="See how all the names ranked."
+								/>
+								<div className="w-full">
+									<Suspense fallback={<Loading variant="skeleton" height={600} />}>
+										<ErrorBoundary context={errorContexts.analysisDashboard}>
+											<DashboardLazy
+												personalRatings={tournament.ratings}
+												currentTournamentNames={tournament.names ?? undefined}
+												onStartNew={handleStartNewTournament}
+												onUpdateRatings={tournamentActions.setRatings}
+												userName={user.name ?? ""}
+												isAdmin={user.isAdmin}
+												isLoggedIn={user.isLoggedIn}
+												avatarUrl={user.avatarUrl}
+											/>
+										</ErrorBoundary>
+									</Suspense>
+								</div>
+							</div>
 						</div>
-					</div>
-				</div>
-			</Section>
-		</>
+					</Section>
+				),
+			}}
+		/>
 	);
 }

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -2,12 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useCallback, useEffect } from "react";
 import { errorContexts, routeComponents } from "@/app/appConfig";
 import { HomeHeroSection } from "@/app/routes/components/HomeSections";
-import { SectionFlow } from "@/shared/components/ui/SectionFlow";
 import { namesQueryOptions } from "@/shared/api/names/api";
 import { ErrorBoundary } from "@/shared/components/layout/Feedback/ErrorBoundary";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
+import { SectionFlow } from "@/shared/components/ui/SectionFlow";
 import { useSectionScroll } from "@/shared/hooks/useSectionScroll";
 import { getLockedNames } from "@/shared/lib/names/nameFilters";
 import useAppStore from "@/store/appStore";
@@ -121,10 +121,7 @@ export default function HomeRoute() {
 					>
 						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-								<SectionHeading
-									title="Results"
-									subtitle="See how all the names ranked."
-								/>
+								<SectionHeading title="Results" subtitle="See how all the names ranked." />
 								<div className="w-full">
 									<Suspense fallback={<Loading variant="skeleton" height={600} />}>
 										<ErrorBoundary context={errorContexts.analysisDashboard}>

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -5,9 +5,8 @@ import { HomeHeroSection } from "@/app/routes/components/HomeSections";
 import { namesQueryOptions } from "@/shared/api/names/api";
 import { ErrorBoundary } from "@/shared/components/layout/Feedback/ErrorBoundary";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
-import { Section } from "@/shared/components/layout/Section";
-import { SectionHeading } from "@/shared/components/layout/SectionHeading";
 import { SectionFlow } from "@/shared/components/ui/SectionFlow";
+import { SectionPage } from "@/shared/components/ui/SectionPage";
 import { useSectionScroll } from "@/shared/hooks/useSectionScroll";
 import { getLockedNames } from "@/shared/lib/names/nameFilters";
 import useAppStore from "@/store/appStore";
@@ -49,98 +48,67 @@ export default function HomeRoute() {
 					</div>
 				),
 				pick: (
-					<Section
+					<SectionPage
 						id="pick"
-						variant="minimal"
-						padding="comfortable"
+						title="My Cat Needs a Name"
+						subtitle="Pick your favorites. Let's see what wins."
 						maxWidth="xl"
-						separator={true}
-						fullpage={true}
 					>
-						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-								<SectionHeading
-									title="My Cat Needs a Name"
-									subtitle="Pick your favorites. Let's see what wins."
-								/>
-								<div className="w-full">
-									<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-										<TournamentFlow />
-									</Suspense>
-								</div>
-							</div>
-						</div>
-					</Section>
+						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+							<TournamentFlow />
+						</Suspense>
+					</SectionPage>
 				),
 				tournament: (
-					<Section
+					<SectionPage
 						id="tournament"
-						variant="minimal"
-						padding="comfortable"
+						title="But See How I Got There"
+						subtitle="Head-to-head matchups to rank them all."
 						maxWidth="2xl"
-						separator={true}
-						fullpage={true}
 					>
-						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-								<SectionHeading
-									title="But See How I Got There"
-									subtitle="Head-to-head matchups to rank them all."
-								/>
-								<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-									{tournament.names && tournament.names.length > 0 ? (
-										<div className="w-full">
-											<LazyTournament
-												names={tournament.names}
-												existingRatings={tournament.ratings}
-												onComplete={(ratings) => {
-													tournamentActions.completeTournament(ratings);
-												}}
-											/>
-										</div>
-									) : (
-										<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
-											<p className="text-pretty text-sm text-muted-foreground/70">
-												Pick at least 2 names to start comparing them.
-											</p>
-										</div>
-									)}
-								</Suspense>
-							</div>
-						</div>
-					</Section>
+						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+							{tournament.names && tournament.names.length > 0 ? (
+								<div className="w-full">
+									<LazyTournament
+										names={tournament.names}
+										existingRatings={tournament.ratings}
+										onComplete={(ratings) => {
+											tournamentActions.completeTournament(ratings);
+										}}
+									/>
+								</div>
+							) : (
+								<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
+									<p className="text-pretty text-sm text-muted-foreground/70">
+										Pick at least 2 names to start comparing them.
+									</p>
+								</div>
+							)}
+						</Suspense>
+					</SectionPage>
 				),
 				analysis: (
-					<Section
+					<SectionPage
 						id="analysis"
-						variant="minimal"
-						padding="comfortable"
+						title="Results"
+						subtitle="See how all the names ranked."
 						maxWidth="2xl"
-						separator={true}
-						fullpage={true}
 					>
-						<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-							<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-								<SectionHeading title="Results" subtitle="See how all the names ranked." />
-								<div className="w-full">
-									<Suspense fallback={<Loading variant="skeleton" height={600} />}>
-										<ErrorBoundary context={errorContexts.analysisDashboard}>
-											<DashboardLazy
-												personalRatings={tournament.ratings}
-												currentTournamentNames={tournament.names ?? undefined}
-												onStartNew={handleStartNewTournament}
-												onUpdateRatings={tournamentActions.setRatings}
-												userName={user.name ?? ""}
-												isAdmin={user.isAdmin}
-												isLoggedIn={user.isLoggedIn}
-												avatarUrl={user.avatarUrl}
-											/>
-										</ErrorBoundary>
-									</Suspense>
-								</div>
-							</div>
-						</div>
-					</Section>
+						<Suspense fallback={<Loading variant="skeleton" height={600} />}>
+							<ErrorBoundary context={errorContexts.analysisDashboard}>
+								<DashboardLazy
+									personalRatings={tournament.ratings}
+									currentTournamentNames={tournament.names ?? undefined}
+									onStartNew={handleStartNewTournament}
+									onUpdateRatings={tournamentActions.setRatings}
+									userName={user.name ?? ""}
+									isAdmin={user.isAdmin}
+									isLoggedIn={user.isLoggedIn}
+									avatarUrl={user.avatarUrl}
+								/>
+							</ErrorBoundary>
+						</Suspense>
+					</SectionPage>
 				),
 			}}
 		/>

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
-import { themeText } from "@/shared/lib/themeClasses";
 import { TIMING } from "@/shared/lib/constants";
+import { themeText } from "@/shared/lib/themeClasses";
 import type { NameItem } from "@/shared/types";
 
 type HomeHeroState = "loading" | "ready" | "error";

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -1,33 +1,13 @@
 import { motion } from "framer-motion";
-import { type ComponentType, type LazyExoticComponent, Suspense } from "react";
-import Button from "@/shared/components/layout/Button";
-import { Loading } from "@/shared/components/layout/Feedback/Loading";
-import { Section } from "@/shared/components/layout/Section";
-import { SectionHeading } from "@/shared/components/layout/SectionHeading";
 import { themeText } from "@/shared/lib/themeClasses";
 import { TIMING } from "@/shared/lib/constants";
-import type { NameItem, RatingData } from "@/shared/types";
+import type { NameItem } from "@/shared/types";
 
 type HomeHeroState = "loading" | "ready" | "error";
 
 interface HomeHeroSectionProps {
 	state: HomeHeroState;
 	lockedNames: NameItem[];
-	onStartPicking: () => void;
-}
-
-interface TournamentBracketSectionProps {
-	LazyTournament: LazyExoticComponent<
-		ComponentType<{
-			names: NameItem[];
-			existingRatings?: Record<string, RatingData>;
-			onComplete: (ratings: Record<string, RatingData>) => void;
-		}>
-	>;
-	names: NameItem[] | null | undefined;
-	ratings: Record<string, RatingData>;
-	onComplete: (ratings: Record<string, RatingData>) => void;
-	onGoToPicker: () => void;
 }
 
 function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNames: NameItem[] }) {
@@ -51,94 +31,45 @@ function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNam
 	);
 }
 
-export function HomeHeroSection({ state, lockedNames, onStartPicking }: HomeHeroSectionProps) {
+export function HomeHeroSection({ state, lockedNames }: HomeHeroSectionProps) {
 	return (
-		<div className="home-hero-wrapper w-full">
-			<section className="relative isolate flex min-h-[100dvh] w-full flex-col items-center justify-center overflow-hidden text-foreground px-6 text-center">
-				<motion.div
-					initial={{ opacity: 0, y: -20 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.6, ease: "easeOut" }}
-					className="flex flex-col items-center justify-center text-center max-w-4xl gap-8 md:gap-12"
-				>
-					<motion.p
-						initial={{ opacity: 0, y: 10 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ delay: 0.1, duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
-						className="text-sm font-medium uppercase tracking-wider text-muted-foreground/70"
-					>
-						What should we name my cat?
-					</motion.p>
-
-					<motion.div
-						initial={{ opacity: 0, scale: 0.9 }}
-						animate={{ opacity: 1, scale: 1 }}
-						transition={{ delay: 0.2, duration: TIMING.MOTION_SLOW, ease: TIMING.MOTION_EASING }}
-					>
-						<h1
-							className={`${themeText.heroDisplay} tracking-tighter`}
-							style={{ fontSize: "clamp(2.5rem, 8vw, 6.5rem)", lineHeight: 1.05 }}
-						>
-							<HeroNameWords state={state} lockedNames={lockedNames} />
-						</h1>
-					</motion.div>
-
-					<motion.h2
-						initial={{ opacity: 0, y: 10 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ delay: 0.35, duration: TIMING.MOTION_SLOW, ease: TIMING.MOTION_EASING }}
-						className="text-lg sm:text-xl md:text-2xl font-semibold tracking-tight text-foreground/85 text-center max-w-2xl px-4"
-						style={{ lineHeight: 1.4 }}
-					>
-						Pick your favorites and see which names score highest with your friends.
-					</motion.h2>
-
-					<motion.div
-						initial={{ opacity: 0, y: 20, scale: 0.95 }}
-						animate={{ opacity: 1, y: 0, scale: 1 }}
-						transition={{ delay: 0.5, duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
-						className="mt-6"
-					>
-						<Button variant="glass" size="lg" onClick={onStartPicking}>
-							Get Started
-						</Button>
-					</motion.div>
-				</motion.div>
-			</section>
-		</div>
-	);
-}
-
-export function TournamentBracketSection({
-	LazyTournament,
-	names,
-	ratings,
-	onComplete,
-	onGoToPicker,
-}: TournamentBracketSectionProps) {
-	return (
-		<Section
-			id="tournament"
-			variant="minimal"
-			padding="comfortable"
-			maxWidth="2xl"
-			separator={true}
+		<motion.div
+			initial={{ opacity: 0, y: -20 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.6, ease: "easeOut" }}
+			className="flex flex-col items-center justify-center text-center max-w-4xl gap-8 md:gap-12"
 		>
-			<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
-			<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-				{names && names.length > 0 ? (
-					<LazyTournament names={names} existingRatings={ratings} onComplete={onComplete} />
-				) : (
-					<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 py-12 text-center">
-						<p className="text-pretty text-sm text-muted-foreground/70">
-							Pick at least 2 names to start comparing them.
-						</p>
-						<Button variant="glass" onClick={onGoToPicker}>
-							← Back
-						</Button>
-					</div>
-				)}
-			</Suspense>
-		</Section>
+			<motion.p
+				initial={{ opacity: 0, y: 10 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ delay: 0.1, duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
+				className="text-sm font-medium uppercase tracking-wider text-muted-foreground/70"
+			>
+				What should we name my cat?
+			</motion.p>
+
+			<motion.div
+				initial={{ opacity: 0, scale: 0.9 }}
+				animate={{ opacity: 1, scale: 1 }}
+				transition={{ delay: 0.2, duration: TIMING.MOTION_SLOW, ease: TIMING.MOTION_EASING }}
+			>
+				<h1
+					className={`${themeText.heroDisplay} tracking-tighter`}
+					style={{ fontSize: "clamp(2.5rem, 8vw, 6.5rem)", lineHeight: 1.05 }}
+				>
+					<HeroNameWords state={state} lockedNames={lockedNames} />
+				</h1>
+			</motion.div>
+
+			<motion.h2
+				initial={{ opacity: 0, y: 10 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ delay: 0.35, duration: TIMING.MOTION_SLOW, ease: TIMING.MOTION_EASING }}
+				className="text-lg sm:text-xl md:text-2xl font-semibold tracking-tight text-foreground/85 text-center max-w-2xl px-4"
+				style={{ lineHeight: 1.4 }}
+			>
+				Pick your favorites and see which names score highest with your friends.
+			</motion.h2>
+		</motion.div>
 	);
 }

--- a/src/features/dashboard/components/analytics/Dashboard.tsx
+++ b/src/features/dashboard/components/analytics/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { Activity, BarChart3, Eye, EyeOff, Target, TrendingUp, Trophy, Users } from "lucide-react";
 import Button from "@/shared/components/layout/Button";
 import { EmptyState } from "@/shared/components/layout/EmptyState";
-import { themeSurfaces, themeText } from "@/shared/lib/themeClasses";
+import { themeSurfaces } from "@/shared/lib/themeClasses";
 import type { SiteStats, UserStats } from "@/shared/services/supabase/statsService";
 import type { NameItem, RatingData } from "@/shared/types";
 import {
@@ -91,7 +91,6 @@ function getQuickStats({
 
 	return [];
 }
-
 
 function DashboardHeader({
 	isLoggedIn,
@@ -354,7 +353,7 @@ export function Dashboard({
 	const quickStats = getQuickStats({ siteStats, userName, userStats });
 	const hasPersonalRatings = Boolean(personalRatings && Object.keys(personalRatings).length > 0);
 	const hasCommunityData = leaderboard.length > 0 || Boolean(siteStats);
-	const shouldShowDashboardPrimer =
+	const _shouldShowDashboardPrimer =
 		!hasPersonalRatings && !isLoadingLeaderboard && !hasCommunityData;
 
 	return (
@@ -367,7 +366,6 @@ export function Dashboard({
 				quickStats={quickStats}
 				userStats={userStats}
 			/>
-
 
 			{hasPersonalRatings && onUpdateRatings && (
 				<Panel>

--- a/src/features/dashboard/components/analytics/RankingAdjustment.tsx
+++ b/src/features/dashboard/components/analytics/RankingAdjustment.tsx
@@ -30,7 +30,8 @@ const RankingItemContent = memo(({ item, index }: { item: NameItem; index: numbe
 		1: "from-slate-300 to-slate-500",
 		2: "from-amber-700 to-orange-800",
 	};
-	const medalBg = index < 3 ? medalColors[index as keyof typeof medalColors] : "from-primary/20 to-accent/20";
+	const medalBg =
+		index < 3 ? medalColors[index as keyof typeof medalColors] : "from-primary/20 to-accent/20";
 	const medalBorder = index < 3 ? "border-yellow-600/50" : "border-primary/30";
 	const medalText = index < 3 ? "text-white" : "text-foreground";
 

--- a/src/features/dashboard/components/analytics/components/DashboardPrimitives.tsx
+++ b/src/features/dashboard/components/analytics/components/DashboardPrimitives.tsx
@@ -119,12 +119,16 @@ export function StatTile({
 			<div className="absolute -top-6 -right-6 size-12 rounded-full bg-primary/5 blur-xl transition-transform group-hover:scale-110" />
 			<div className="relative space-y-2">
 				<div className="flex items-center justify-between">
-					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+					<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+						{label}
+					</p>
 					{Icon && (
-						<div className={cn(
-							"rounded-lg p-2 transition-colors",
-							accent ? "bg-primary/20 text-primary" : "bg-muted text-muted-foreground"
-						)}>
+						<div
+							className={cn(
+								"rounded-lg p-2 transition-colors",
+								accent ? "bg-primary/20 text-primary" : "bg-muted text-muted-foreground",
+							)}
+						>
 							<Icon size={14} />
 						</div>
 					)}

--- a/src/features/dashboard/components/analytics/components/LeaderboardPanel.tsx
+++ b/src/features/dashboard/components/analytics/components/LeaderboardPanel.tsx
@@ -55,19 +55,25 @@ export function LeaderboardPanel({
 								divided={index < leaderboard.length - 1}
 								className="hover:bg-muted/40 transition-colors"
 							>
-								<div className={cn(
-									"flex items-center justify-center text-sm font-bold min-w-[2.5rem] rounded-lg",
-									index < 3
-										? "bg-gradient-to-br from-yellow-600/20 to-amber-600/20 text-lg"
-										: `flex size-9 items-center justify-center rounded-full ${themeSurfaces.avatar}`
-								)}>
+								<div
+									className={cn(
+										"flex items-center justify-center text-sm font-bold min-w-[2.5rem] rounded-lg",
+										index < 3
+											? "bg-gradient-to-br from-yellow-600/20 to-amber-600/20 text-lg"
+											: `flex size-9 items-center justify-center rounded-full ${themeSurfaces.avatar}`,
+									)}
+								>
 									{medal || index + 1}
 								</div>
 								<div className="min-w-0 flex-1">
 									<p className="truncate text-sm font-semibold text-foreground">{entry.name}</p>
 									<div className="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground/70">
-										<span>📊 {entry.total_ratings} rating{entry.total_ratings === 1 ? "" : "s"}</span>
-										<span>🏆 {entry.wins} win{entry.wins === 1 ? "" : "s"}</span>
+										<span>
+											📊 {entry.total_ratings} rating{entry.total_ratings === 1 ? "" : "s"}
+										</span>
+										<span>
+											🏆 {entry.wins} win{entry.wins === 1 ? "" : "s"}
+										</span>
 									</div>
 								</div>
 								<div className="text-right flex flex-col items-end gap-1">

--- a/src/features/tournament/Tournament.tsx
+++ b/src/features/tournament/Tournament.tsx
@@ -168,7 +168,9 @@ function TournamentContent({ onComplete, names = [], onVote }: TournamentProps) 
 				const participant = currentMatch[side];
 				const id = typeof participant === "object" ? String(participant.id) : String(participant);
 				const name =
-					currentMatch.mode === "2v2" && typeof participant === "object" && "memberNames" in participant
+					currentMatch.mode === "2v2" &&
+					typeof participant === "object" &&
+					"memberNames" in participant
 						? (participant.memberNames ?? []).join(" + ") || String(participant.id)
 						: typeof participant === "object"
 							? participant.name

--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -940,8 +940,8 @@ export function NameSelector() {
 								<div className="mt-4">
 									{isSwipeMode && (
 										<p className="mb-3 text-sm leading-relaxed text-muted-foreground/75">
-											Archived names stay out of the swipe deck, but you can still inspect and select
-											them here without leaving swipe mode.
+											Archived names stay out of the swipe deck, but you can still inspect and
+											select them here without leaving swipe mode.
 										</p>
 									)}
 

--- a/src/features/tournament/components/name-selector/nameSelectorUtils.ts
+++ b/src/features/tournament/components/name-selector/nameSelectorUtils.ts
@@ -12,7 +12,8 @@ export const getCardStyles = (isSelected: boolean, isLocked: boolean) => {
 
 // Name overlay styles utility
 export const getNameOverlayClasses = (variant: "grid" | "swipe") => {
-	const baseClasses = "absolute inset-0 flex flex-col items-center justify-center pointer-events-none";
+	const baseClasses =
+		"absolute inset-0 flex flex-col items-center justify-center pointer-events-none";
 	const gridClasses =
 		"p-4 sm:p-5 bg-gradient-to-t from-slate-950/95 via-slate-950/55 to-transparent text-center";
 	const swipeClasses =

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 /* Hide Builder.io dev attributes */
 [data-loc] {
-	outline: none !important;
+	outline: none;
 }
 
 /* Section visibility toggle animation */

--- a/src/shared/components/ui/NavbarModals.tsx
+++ b/src/shared/components/ui/NavbarModals.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
-import { Modal } from "@/shared/components/layout/Modal";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
+import { Modal } from "@/shared/components/layout/Modal";
 
 const LazyProfileInner = lazy(() =>
 	import("@/shared/components/profile/ProfileInner").then((module) => ({

--- a/src/shared/components/ui/SectionFlow.tsx
+++ b/src/shared/components/ui/SectionFlow.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { type ReactNode, useCallback, useState } from "react";
 
 type Section = "hero" | "pick" | "tournament" | "analysis";
@@ -21,16 +21,26 @@ const SECTION_ORDER: Record<Section, number> = {
 	analysis: 3,
 };
 
+const SECTION_LABELS: Record<Section, string> = {
+	hero: "Start",
+	pick: "Pick",
+	tournament: "Battle",
+	analysis: "Results",
+};
+
 export function SectionFlow({ sections, onSectionChange }: SectionFlowProps) {
 	const [current, setCurrent] = useState<Section>("hero");
+	const [direction, setDirection] = useState(0);
 	const currentIndex = SECTION_ORDER[current];
 
 	const navigate = useCallback(
 		(target: Section) => {
+			const targetIndex = SECTION_ORDER[target];
+			setDirection(targetIndex > currentIndex ? 1 : -1);
 			setCurrent(target);
 			onSectionChange?.(target);
 		},
-		[onSectionChange],
+		[currentIndex, onSectionChange],
 	);
 
 	const next = useCallback(() => {
@@ -43,14 +53,29 @@ export function SectionFlow({ sections, onSectionChange }: SectionFlowProps) {
 		navigate(prevSection);
 	}, [currentIndex, navigate]);
 
+	const handleSwipe = (e: React.TouchEvent<HTMLDivElement>) => {
+		const touch = e.changedTouches[0];
+		if (!touch) {
+			return;
+		}
+		const delta = touch.clientX - (e.currentTarget._startX ?? touch.clientX);
+		if (Math.abs(delta) > 50) {
+			delta > 0 ? prev() : next();
+		}
+	};
+
 	return (
 		<motion.div
 			key={current}
-			initial={{ opacity: 0, y: 20 }}
-			animate={{ opacity: 1, y: 0 }}
-			exit={{ opacity: 0, y: -20 }}
-			transition={{ duration: 0.3 }}
+			initial={{ opacity: 0, x: direction * 50 }}
+			animate={{ opacity: 1, x: 0 }}
+			exit={{ opacity: 0, x: -direction * 50 }}
+			transition={{ duration: 0.4, ease: "easeInOut" }}
 			className="w-full"
+			onTouchStart={(e) => {
+				(e.currentTarget as any)._startX = e.touches[0].clientX;
+			}}
+			onTouchEnd={handleSwipe}
 		>
 			<div
 				data-section={current}
@@ -69,7 +94,7 @@ export function SectionFlow({ sections, onSectionChange }: SectionFlowProps) {
 				{sections[current]}
 			</div>
 
-			<SectionFlowNav
+			<MagneticNav
 				current={current}
 				canGoPrev={currentIndex > 0}
 				canGoNext={currentIndex < SECTIONS.length - 1}
@@ -81,7 +106,7 @@ export function SectionFlow({ sections, onSectionChange }: SectionFlowProps) {
 	);
 }
 
-interface SectionFlowNavProps {
+interface MagneticNavProps {
 	current: Section;
 	canGoPrev: boolean;
 	canGoNext: boolean;
@@ -90,47 +115,80 @@ interface SectionFlowNavProps {
 	onNavigate: (section: Section) => void;
 }
 
-function SectionFlowNav({
+function MagneticNav({
 	current,
 	canGoPrev,
 	canGoNext,
 	onPrev,
 	onNext,
 	onNavigate,
-}: SectionFlowNavProps) {
+}: MagneticNavProps) {
+	const [hover, setHover] = useState<Section | null>(null);
+
 	return (
-		<div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 bg-black/40 backdrop-blur-md px-4 py-2 rounded-full border border-white/10">
-			<button
-				onClick={onPrev}
-				disabled={!canGoPrev}
-				className="px-3 py-1 text-sm font-medium text-white/70 disabled:opacity-20 hover:text-white transition-colors"
-				aria-label="Previous section"
+		<div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-40">
+			<motion.div
+				className="flex items-center gap-6 px-8 py-3 rounded-full bg-black/50 backdrop-blur-lg border border-white/10 shadow-2xl"
+				layout={true}
 			>
-				← Back
-			</button>
+				<motion.button
+					onClick={onPrev}
+					disabled={!canGoPrev}
+					whileHover={{ scale: canGoPrev ? 1.15 : 1 }}
+					whileTap={{ scale: canGoPrev ? 0.9 : 1 }}
+					className="px-2 text-sm font-medium text-white/60 disabled:opacity-20 hover:text-white transition-colors cursor-pointer"
+					aria-label="Previous section"
+				>
+					←
+				</motion.button>
 
-			<div className="flex gap-1">
-				{(["hero", "pick", "tournament", "analysis"] as Section[]).map((section) => (
-					<button
-						key={section}
-						onClick={() => onNavigate(section)}
-						className={`w-2 h-2 rounded-full transition-all ${
-							section === current ? "bg-white w-6" : "bg-white/30 hover:bg-white/50"
-						}`}
-						aria-label={`Go to ${section}`}
-						aria-current={section === current ? "page" : undefined}
-					/>
-				))}
-			</div>
+				<div className="flex gap-4 px-4">
+					<AnimatePresence mode="wait">
+						{(["hero", "pick", "tournament", "analysis"] as Section[]).map((section) => (
+							<motion.button
+								key={section}
+								onClick={() => onNavigate(section)}
+								onHoverStart={() => setHover(section)}
+								onHoverEnd={() => setHover(null)}
+								layout={true}
+								initial={{ scale: 0.8, opacity: 0.5 }}
+								animate={{
+									scale: section === current ? 1.2 : hover === section ? 1.1 : 0.95,
+									opacity: section === current ? 1 : hover === section ? 0.8 : 0.4,
+								}}
+								transition={{ type: "spring", stiffness: 300, damping: 30 }}
+								className={`relative w-10 h-10 rounded-full transition-all ${
+									section === current ? "bg-white/90 shadow-lg" : "bg-white/20 hover:bg-white/40"
+								}`}
+								aria-label={`Go to ${SECTION_LABELS[section]}`}
+								aria-current={section === current ? "page" : undefined}
+							>
+								<motion.div
+									className="absolute inset-0 rounded-full bg-gradient-to-br from-white/40 to-transparent opacity-0"
+									animate={{
+										opacity: hover === section ? 1 : 0,
+									}}
+									transition={{ duration: 0.2 }}
+								/>
+								<span className="text-xs font-bold text-center leading-10 text-black/70">
+									{SECTION_LABELS[section].charAt(0)}
+								</span>
+							</motion.button>
+						))}
+					</AnimatePresence>
+				</div>
 
-			<button
-				onClick={onNext}
-				disabled={!canGoNext}
-				className="px-3 py-1 text-sm font-medium text-white/70 disabled:opacity-20 hover:text-white transition-colors"
-				aria-label="Next section"
-			>
-				Next →
-			</button>
+				<motion.button
+					onClick={onNext}
+					disabled={!canGoNext}
+					whileHover={{ scale: canGoNext ? 1.15 : 1 }}
+					whileTap={{ scale: canGoNext ? 0.9 : 1 }}
+					className="px-2 text-sm font-medium text-white/60 disabled:opacity-20 hover:text-white transition-colors cursor-pointer"
+					aria-label="Next section"
+				>
+					→
+				</motion.button>
+			</motion.div>
 		</div>
 	);
 }

--- a/src/shared/components/ui/SectionFlow.tsx
+++ b/src/shared/components/ui/SectionFlow.tsx
@@ -56,8 +56,12 @@ export function SectionFlow({ sections, onSectionChange }: SectionFlowProps) {
 				data-section={current}
 				className="w-full"
 				onKeyDown={(e) => {
-					if (e.key === "ArrowRight" || e.key === "l") next();
-					if (e.key === "ArrowLeft" || e.key === "h") prev();
+					if (e.key === "ArrowRight" || e.key === "l") {
+						next();
+					}
+					if (e.key === "ArrowLeft" || e.key === "h") {
+						prev();
+					}
 				}}
 				role="region"
 				aria-label={`Section: ${current}`}

--- a/src/shared/components/ui/SectionFlow.tsx
+++ b/src/shared/components/ui/SectionFlow.tsx
@@ -1,0 +1,132 @@
+import { motion } from "framer-motion";
+import { type ReactNode, useCallback, useState } from "react";
+
+type Section = "hero" | "pick" | "tournament" | "analysis";
+
+interface SectionFlowProps {
+	sections: {
+		hero: ReactNode;
+		pick: ReactNode;
+		tournament: ReactNode;
+		analysis: ReactNode;
+	};
+	onSectionChange?: (section: Section) => void;
+}
+
+const SECTIONS: Section[] = ["hero", "pick", "tournament", "analysis"];
+const SECTION_ORDER: Record<Section, number> = {
+	hero: 0,
+	pick: 1,
+	tournament: 2,
+	analysis: 3,
+};
+
+export function SectionFlow({ sections, onSectionChange }: SectionFlowProps) {
+	const [current, setCurrent] = useState<Section>("hero");
+	const currentIndex = SECTION_ORDER[current];
+
+	const navigate = useCallback(
+		(target: Section) => {
+			setCurrent(target);
+			onSectionChange?.(target);
+		},
+		[onSectionChange],
+	);
+
+	const next = useCallback(() => {
+		const nextSection = SECTIONS[Math.min(currentIndex + 1, SECTIONS.length - 1)];
+		navigate(nextSection);
+	}, [currentIndex, navigate]);
+
+	const prev = useCallback(() => {
+		const prevSection = SECTIONS[Math.max(currentIndex - 1, 0)];
+		navigate(prevSection);
+	}, [currentIndex, navigate]);
+
+	return (
+		<motion.div
+			key={current}
+			initial={{ opacity: 0, y: 20 }}
+			animate={{ opacity: 1, y: 0 }}
+			exit={{ opacity: 0, y: -20 }}
+			transition={{ duration: 0.3 }}
+			className="w-full"
+		>
+			<div
+				data-section={current}
+				className="w-full"
+				onKeyDown={(e) => {
+					if (e.key === "ArrowRight" || e.key === "l") next();
+					if (e.key === "ArrowLeft" || e.key === "h") prev();
+				}}
+				role="region"
+				aria-label={`Section: ${current}`}
+			>
+				{sections[current]}
+			</div>
+
+			<SectionFlowNav
+				current={current}
+				canGoPrev={currentIndex > 0}
+				canGoNext={currentIndex < SECTIONS.length - 1}
+				onNext={next}
+				onPrev={prev}
+				onNavigate={navigate}
+			/>
+		</motion.div>
+	);
+}
+
+interface SectionFlowNavProps {
+	current: Section;
+	canGoPrev: boolean;
+	canGoNext: boolean;
+	onPrev: () => void;
+	onNext: () => void;
+	onNavigate: (section: Section) => void;
+}
+
+function SectionFlowNav({
+	current,
+	canGoPrev,
+	canGoNext,
+	onPrev,
+	onNext,
+	onNavigate,
+}: SectionFlowNavProps) {
+	return (
+		<div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 bg-black/40 backdrop-blur-md px-4 py-2 rounded-full border border-white/10">
+			<button
+				onClick={onPrev}
+				disabled={!canGoPrev}
+				className="px-3 py-1 text-sm font-medium text-white/70 disabled:opacity-20 hover:text-white transition-colors"
+				aria-label="Previous section"
+			>
+				← Back
+			</button>
+
+			<div className="flex gap-1">
+				{(["hero", "pick", "tournament", "analysis"] as Section[]).map((section) => (
+					<button
+						key={section}
+						onClick={() => onNavigate(section)}
+						className={`w-2 h-2 rounded-full transition-all ${
+							section === current ? "bg-white w-6" : "bg-white/30 hover:bg-white/50"
+						}`}
+						aria-label={`Go to ${section}`}
+						aria-current={section === current ? "page" : undefined}
+					/>
+				))}
+			</div>
+
+			<button
+				onClick={onNext}
+				disabled={!canGoNext}
+				className="px-3 py-1 text-sm font-medium text-white/70 disabled:opacity-20 hover:text-white transition-colors"
+				aria-label="Next section"
+			>
+				Next →
+			</button>
+		</div>
+	);
+}

--- a/src/shared/components/ui/SectionPage.tsx
+++ b/src/shared/components/ui/SectionPage.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { Section } from "@/shared/components/layout/Section";
+import { SectionHeading } from "@/shared/components/layout/SectionHeading";
+
+interface SectionPageProps {
+	id: string;
+	title: string;
+	subtitle: string;
+	children: ReactNode;
+	maxWidth?: "xl" | "2xl";
+}
+
+export function SectionPage({ id, title, subtitle, children, maxWidth = "2xl" }: SectionPageProps) {
+	return (
+		<Section
+			id={id}
+			variant="minimal"
+			padding="comfortable"
+			maxWidth={maxWidth}
+			separator={true}
+			fullpage={true}
+		>
+			<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+				<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+					<SectionHeading title={title} subtitle={subtitle} />
+					{children}
+				</div>
+			</div>
+		</Section>
+	);
+}

--- a/src/shared/hooks/useSectionScroll.ts
+++ b/src/shared/hooks/useSectionScroll.ts
@@ -6,7 +6,9 @@ export function useSectionScroll() {
 	const pendingScrollRef = useRef<number | null>(null);
 
 	const clearPendingScroll = useCallback(() => {
-		if (pendingScrollRef.current === null) return;
+		if (pendingScrollRef.current === null) {
+			return;
+		}
 		window.clearTimeout(pendingScrollRef.current);
 		pendingScrollRef.current = null;
 	}, []);


### PR DESCRIPTION
## Summary
- Replaced the scroll-based multi-section layout in `HomeRoute` with a new `SectionFlow` component that manages section state internally via animated transitions
- Added `SectionFlow` (`src/shared/components/ui/SectionFlow.tsx`) — a self-contained component with animated slide transitions, swipe gesture support, keyboard navigation (arrow keys), and a fixed `MagneticNav` pill at the bottom for section navigation
- Added `SectionPage` (`src/shared/components/ui/SectionPage.tsx`) — a reusable wrapper that composes `Section` + `SectionHeading` to reduce repetition across the four home sections
- Removed scattered inline `Button` nav controls (Back/Next) from each section and the `scrollToSection` / `scheduleSectionScroll` calls; navigation is now fully owned by `SectionFlow`
- Minor cleanup: import reordering, CSS `!important` removal, and line-length formatting fixes

## Scope
- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level
- [x] Medium (feature logic change)

> Navigation between home sections is now state-driven (React state + framer-motion) rather than scroll-driven. The `useSectionScroll` hook is still present but only `clearPendingScroll` is used.

## Validation
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Tests added/updated for behavior changes
- [ ] Manual QA steps documented below

## Manual QA
1. Load the home route (`/`) — confirm the hero section renders correctly
2. Use the `MagneticNav` pill at the bottom to navigate to **Pick**, **Battle**, and **Results** sections
3. Verify animated slide transitions play correctly when moving forward and backward
4. On a touch device (or DevTools touch emulation), swipe left/right to confirm gesture navigation works
5. Press `ArrowRight` / `ArrowLeft` (or `l` / `h`) to confirm keyboard navigation
6. Pick at least 2 names → navigate to Battle → complete tournament → confirm Results section loads with dashboard
7. Confirm "Start New" flow resets state correctly
8. Confirm no runtime errors related to `AppShell.tsx` dynamic import

## Rollout + Revert Plan
- Rollout approach: Standard deploy — no feature flags needed; purely frontend layout change
- Revert command/path: Revert the commits touching `HomeRoute.tsx`, `HomeSections.tsx`, `SectionFlow.tsx`, and `SectionPage.tsx`

## Related
- Any follow-up work: Consider extracting `MagneticNav` into its own file under `components/ui/` if it grows; evaluate whether `useSectionScroll` can be fully removed now that scroll-based navigation is gone


---

<a href="https://builder.io/app/projects/9de253cd38884a38a783/lean-beacon-i4ybuegj"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://9de253cd38884a38a783-lean-beacon-i4ybuegj_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=9de253cd38884a38a783&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1003`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9de253cd38884a38a783</projectId>-->
<!--<branchName>lean-beacon-i4ybuegj</branchName>-->