### PR TITLE
Fix tournament start by deferring selection sync

### DIFF
--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -148,11 +148,11 @@ export function NameSelector() {
 		(nameId: IdType) => {
 			setSelectedNames((prev) => {
 				const next = toggleInSet(prev, nameId);
-				syncSelectionToStore(next);
+				deferredSync(() => syncSelectionToStore(next));
 				return next;
 			});
 		},
-		[syncSelectionToStore],
+		[syncSelectionToStore, deferredSync],
 	);
 
 	// Trigger haptic feedback if available


### PR DESCRIPTION
## Summary
- The "Start Tournament" button was not functioning correctly due to a synchronous selection sync call inside a state updater
- Wrapped `syncSelectionToStore` in `deferredSync` within the `NameSelector` toggle handler to ensure the store update happens after the state has settled
- Added `deferredSync` to the `useCallback` dependency array to keep the closure correct

## Scope
- [x] Frontend
- [ ] Backend
- [ ] Supabase/SQL migration
- [ ] Tooling/CI
- [ ] Documentation only

## Risk Level
- [ ] Low (refactor/docs/tests)
- [x] Medium (feature logic change)
- [ ] High (auth/data/security/infra)

## Validation
- [ ] `pnpm run lint`
- [ ] `pnpm run build`
- [ ] Tests added/updated for behavior changes
- [ ] Manual QA steps documented below

## Manual QA
1. Navigate to the Tournament feature
2. Add/select participant names using the Name Selector
3. Verify that toggling names updates the selection correctly
4. Confirm the "Start Tournament" button becomes active and starts the tournament as expected

## Rollout + Revert Plan
- Rollout approach: Standard deploy — frontend-only change with no data or API impact
- Revert command/path: Revert the `deferredSync` wrapping in `NameSelector.tsx` and restore direct `syncSelectionToStore(next)` call

## Related
- Issue/Task: Start Tournament button not responding to name selection
- Any follow-up work: Audit other selection sync calls for similar deferred-sync needs


---

<a href="https://builder.io/app/projects/9de253cd38884a38a783/straight-window-lbqhyq7i"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://9de253cd38884a38a783-straight-window-lbqhyq7i_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=9de253cd38884a38a783&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1008`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9de253cd38884a38a783</projectId>-->
<!--<branchName>straight-window-lbqhyq7i</branchName>-->