### PR TITLE
feat(a11y): add ARIA tab roles to AdminTabNav component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-12 - Added ARIA attributes to navigation tabs
+**Learning:** `AdminTabNav` uses generic string labels, but as a navigation element, buttons functioning as tabs should explicitly declare their `role="tab"` and indicate selection state via `aria-selected` rather than relying purely on visual highlighting. This is a crucial semantic UX enhancement for screen reader users navigating tablists.
+**Action:** Always verify components mapped from arrays that represent tabs or selectable lists use appropriate ARIA roles (`role="tab"`) and states (`aria-selected`).

--- a/src/features/dashboard/components/admin/components/AdminTabNav.tsx
+++ b/src/features/dashboard/components/admin/components/AdminTabNav.tsx
@@ -6,10 +6,17 @@ export function AdminTabNav<TTab extends string>({
 	onTabChange,
 }: AdminTabNavProps<TTab>) {
 	return (
-		<div className="flex gap-1 sm:gap-2 mb-4 sm:mb-6 border-b border-border/10 overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
+		<div
+			className="flex gap-1 sm:gap-2 mb-4 sm:mb-6 border-b border-border/10 overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0"
+			role="tablist"
+			aria-label="Admin settings tabs"
+		>
 			{tabs.map((tab) => (
 				<button
 					key={tab.id}
+					type="button"
+					role="tab"
+					aria-selected={activeTab === tab.id}
 					onClick={() => onTabChange(tab.id)}
 					className={`px-3 sm:px-4 py-2 font-medium text-sm whitespace-nowrap transition-colors ${
 						activeTab === tab.id


### PR DESCRIPTION
This PR introduces a small UX/accessibility enhancement by adding explicit `role="tablist"`, `role="tab"`, and `aria-selected` attributes to the `AdminTabNav` component. These additions ensure the component communicates its correct semantic purpose as a tabbed interface to screen readers, improving the overall accessibility of the admin dashboard.

No visual or functional regressions were introduced. Evaluated and tested successfully with pre-existing tests.

---
*PR created automatically by Jules for task [193318777496693064](https://jules.google.com/task/193318777496693064) started by @guitarbeat*

## Summary by Sourcery

Improve accessibility of the AdminTabNav component by exposing it as a proper ARIA tablist with selectable tabs and documenting the change in the Jules palette.

New Features:
- Expose AdminTabNav as an ARIA-compliant tablist using tab roles and selection state for screen readers.

Documentation:
- Add a Jules palette entry documenting the accessibility improvement and guidance for using ARIA roles on tab-like navigation.