### PR TITLE
feat: add aria-labels to select elements for accessibility

### DIFF
--- a/src/features/dashboard/components/admin/components/AdminNamesTab.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNamesTab.tsx
@@ -62,6 +62,7 @@ export function AdminNamesTab({
 						value={filterStatus}
 						onChange={onFilterChange}
 						className="px-4 py-2 bg-foreground/10 border border-border/20 rounded-lg text-foreground"
+						aria-label="Filter names by status"
 					>
 						{filterOptions.map((option) => (
 							<option value={option.value} key={option.value}>

--- a/src/features/dashboard/components/analytics/Dashboard.tsx
+++ b/src/features/dashboard/components/analytics/Dashboard.tsx
@@ -303,6 +303,7 @@ function EngagementPanel({
 							value={timeframe}
 							onChange={(event) => setTimeframe(event.target.value as DashboardTimeframe)}
 							className={`rounded-xl px-3 py-2 text-sm text-foreground ${themeSurfaces.panelDense}`}
+							aria-label="Select timeframe for dashboard analytics"
 						>
 							<option value="day">24 hours</option>
 							<option value="week">Week</option>

--- a/src/features/dashboard/components/analytics/components/RecentActivityPanel.tsx
+++ b/src/features/dashboard/components/analytics/components/RecentActivityPanel.tsx
@@ -39,6 +39,7 @@ export function RecentActivityPanel({
 							value={timeframe}
 							onChange={(event) => setTimeframe(event.target.value as DashboardTimeframe)}
 							className="surface-panel-inset rounded-xl px-3 py-2 text-sm text-foreground"
+							aria-label="Select timeframe for recent activity"
 						>
 							<option value="day">24 hours</option>
 							<option value="week">Week</option>


### PR DESCRIPTION
🎨 **Palette: Add aria-labels to select elements**

💡 **What:** Added `aria-label` attributes to `<select>` elements in the Dashboard and Analytics panels.
🎯 **Why:** To make these select dropdowns fully accessible to screen readers, as they do not have explicitly associated `<label>` tags. This ensures users relying on assistive technologies have proper context about what the dropdowns control.
♿ **Accessibility:** This directly fixes a pattern where inputs are not clearly identifiable by screen readers.

**Changes made:**
- `AdminNamesTab.tsx`: Added `aria-label="Filter names by status"`
- `RecentActivityPanel.tsx`: Added `aria-label="Select timeframe for recent activity"`
- `Dashboard.tsx`: Added `aria-label="Select timeframe for dashboard analytics"`

---
*PR created automatically by Jules for task [452485737634012802](https://jules.google.com/task/452485737634012802) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Add descriptive aria-labels to status filter and timeframe select elements in admin and analytics panels to improve screen reader support.