### PR TITLE
fix(a11y): improve accessibility of dismiss buttons

### DIFF
--- a/src/app/providers/toastContext.tsx
+++ b/src/app/providers/toastContext.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import {
 	createContext,
 	type ReactNode,
@@ -106,11 +107,11 @@ function ToastContainer({
 						<span className="flex-1">{toast.message}</span>
 						<button
 							onClick={() => onDismiss(toast.id)}
-							className="ml-2 rounded p-0.5 opacity-70 transition-opacity hover:opacity-100"
+							className="ml-2 rounded p-0.5 opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
 							aria-label="Dismiss"
 							type="button"
 						>
-							X
+							<X className="size-4" />
 						</button>
 					</div>
 				);

--- a/src/shared/components/layout/Feedback/ErrorBoundary.tsx
+++ b/src/shared/components/layout/Feedback/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Copy } from "lucide-react";
+import { Copy, X } from "lucide-react";
 import React, { Component, type ReactNode, useState } from "react";
 import { cn } from "@/shared/lib/utils";
 import { ErrorManager } from "@/shared/services/errorManager";
@@ -444,11 +444,11 @@ const ErrorList: React.FC<ErrorListProps> = ({
 						{onDismiss && (
 							<button
 								onClick={() => onDismiss(i)}
-								className="ml-3 p-1 text-red-400 hover:text-red-100 rounded-full hover:bg-red-500/20 transition-colors"
+								className="ml-3 p-1 text-red-400 hover:text-red-100 rounded-full hover:bg-red-500/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
 								aria-label="Dismiss error"
 								type="button"
 							>
-								x
+								<X className="size-3" />
 							</button>
 						)}
 					</div>


### PR DESCRIPTION
* Replaced plain text "X" in toast dismiss button with `<X className="size-4" />` from `lucide-react`.
* Replaced plain text "x" in ErrorBoundary dismiss button with `<X className="size-3" />` from `lucide-react`.
* Added `focus-visible` classes to both buttons to improve keyboard accessibility focus rings.

---
*PR created automatically by Jules for task [13415993340978669513](https://jules.google.com/task/13415993340978669513) started by @guitarbeat*

## Summary by Sourcery

Improve accessibility and visual clarity of dismiss buttons in toast notifications and error lists.

Enhancements:
- Replace plain text dismiss indicators with lucide-react X icons in toast and error list components.
- Add focus-visible styles to toast and error dismiss buttons to provide clearer keyboard focus indication.