### PR TITLE
🧹 [code health improvement description]

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -607,6 +607,10 @@ export type Database = {
 				Args: { p_hidden: boolean; p_name_id: string; p_user_name?: string };
 				Returns: boolean;
 			};
+			toggle_name_visibility: {
+				Args: { p_hide: boolean; p_name_id: string; p_user_name?: string };
+				Returns: boolean;
+			};
 			toggle_name_locked_in_debug:
 				| {
 						Args: { p_locked_in: boolean; p_name_id: string };

--- a/src/shared/api/names/api.ts
+++ b/src/shared/api/names/api.ts
@@ -189,7 +189,6 @@ export async function toggleNameHidden(params: {
 	const { isCurrentlyHidden, nameId, userName } = params;
 	const trimmedUserName = userName.trim();
 	await runAdminMutation(async (client) => {
-		// @ts-expect-error - toggle_name_visibility is a custom RPC not in generated types
 		const { data, error } = await client.rpc("toggle_name_visibility", {
 			p_name_id: String(nameId),
 			p_hide: !isCurrentlyHidden,


### PR DESCRIPTION
🎯 **What:** The `toggle_name_visibility` RPC was missing from the generated Supabase types (`src/integrations/supabase/types.ts`), forcing the use of a `@ts-expect-error` suppression at the call site in `src/shared/api/names/api.ts`. This change adds the precise type definition for the RPC.
💡 **Why:** Relying on `@ts-expect-error` creates technical debt and bypasses type safety. By adding the exact signature to the `Database` types, we restore proper TypeScript compilation and inference for this RPC.
✅ **Verification:** Ran `pnpm run lint:types` and `pnpm test run` to ensure the type-checks pass natively and that there are no regressions.
✨ **Result:** Improved code health by removing an unnecessary compiler suppression directive while ensuring accurate type definitions.

---
*PR created automatically by Jules for task [12326537936570318548](https://jules.google.com/task/12326537936570318548) started by @guitarbeat*

## Summary by Sourcery

Define the missing Supabase RPC type for toggling name visibility and remove the associated TypeScript error suppression at its call site.

Enhancements:
- Add the toggle_name_visibility RPC definition to the Supabase Database types to accurately model its arguments and return value.
- Clean up the names API by relying on the typed Supabase RPC instead of a @ts-expect-error suppression.