### PR TITLE
refactor: extract tournament bracket section in home route

### DIFF
--- a/src/app/routes/HomeRoute.test.tsx
+++ b/src/app/routes/HomeRoute.test.tsx
@@ -125,6 +125,21 @@ vi.mock("@/app/routes/components/HomeSections", () => ({
 			</button>
 		</div>
 	),
+	TournamentBracketSection: ({ onComplete, onGoToAnalysis }: any) => (
+		<div>
+			<button
+				type="button"
+				onClick={() => {
+					onComplete({ Miso: { rating: 1200, wins: 1, losses: 0 } });
+				}}
+			>
+				Complete Tournament
+			</button>
+			<button type="button" onClick={onGoToAnalysis}>
+				Go to Analysis
+			</button>
+		</div>
+	),
 }));
 
 vi.mock("@/shared/hooks/useBrowserState", () => ({

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useCallback, useEffect } from "react";
 import { errorContexts, routeComponents } from "@/app/appConfig";
-import { HomeHeroSection } from "@/app/routes/components/HomeSections";
+import { HomeHeroSection, TournamentBracketSection } from "@/app/routes/components/HomeSections";
 import { namesQueryOptions } from "@/shared/api/names/api";
 
 import Button from "@/shared/components/layout/Button";
@@ -9,7 +9,6 @@ import { ErrorBoundary } from "@/shared/components/layout/Feedback/ErrorBoundary
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
-import { SectionNavigation } from "@/shared/components/layout/SectionNavigation";
 import { useSectionScroll } from "@/shared/hooks/useSectionScroll";
 import { getLockedNames } from "@/shared/lib/names/nameFilters";
 import useAppStore from "@/store/appStore";
@@ -64,7 +63,10 @@ export default function HomeRoute() {
 				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
 					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
 						<div>
-							<SectionHeading title="Pick Your Favorites" subtitle="Swipe or click to select names you love." />
+							<SectionHeading
+								title="Pick Your Favorites"
+								subtitle="Swipe or click to select names you love."
+							/>
 						</div>
 						<div className="w-full">
 							<Suspense fallback={<Loading variant="skeleton" height={400} />}>
@@ -83,55 +85,17 @@ export default function HomeRoute() {
 				</div>
 			</Section>
 
-			<Section
-				id="tournament"
-				variant="minimal"
-				padding="comfortable"
-				maxWidth="2xl"
-				separator={true}
-				fullpage={true}
-			>
-				<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
-					<div className="w-full flex flex-col items-center gap-8 md:gap-12">
-						<div>
-							<SectionHeading title="Compare Names" subtitle="Vote on which name you prefer in each matchup." />
-						</div>
-						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-							{tournament.names && tournament.names.length > 0 ? (
-								<>
-									<div className="w-full">
-										<LazyTournament
-											names={tournament.names}
-											existingRatings={tournament.ratings}
-											onComplete={(ratings) => {
-												tournamentActions.completeTournament(ratings);
-												scheduleAnalysisScroll();
-											}}
-										/>
-									</div>
-									<div className="mt-auto pt-8 flex justify-center gap-4">
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-											← Back
-										</Button>
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
-											See Results →
-										</Button>
-									</div>
-								</>
-							) : (
-								<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
-									<p className="text-pretty text-sm text-muted-foreground/70">
-										Pick at least 2 names to start comparing them.
-									</p>
-									<Button variant="glass" onClick={() => scrollToSection("pick")}>
-										← Back
-									</Button>
-								</div>
-							)}
-						</Suspense>
-					</div>
-				</div>
-			</Section>
+			<TournamentBracketSection
+				LazyTournament={LazyTournament}
+				names={tournament.names}
+				ratings={tournament.ratings}
+				onComplete={(ratings) => {
+					tournamentActions.completeTournament(ratings);
+					scheduleAnalysisScroll();
+				}}
+				onGoToPicker={() => scrollToSection("pick")}
+				onGoToAnalysis={() => scrollToSection("analysis")}
+			/>
 
 			<Section
 				id="analysis"

--- a/src/app/routes/components/HomeSections.test.tsx
+++ b/src/app/routes/components/HomeSections.test.tsx
@@ -52,7 +52,7 @@ describe("HomeHeroSection", () => {
 
 		await renderHomeHeroSection({ onStartPicking });
 
-		fireEvent.click(screen.getByText("Narrow It Down"));
+		fireEvent.click(screen.getByText("Get Started"));
 
 		expect(onStartPicking).toHaveBeenCalledTimes(1);
 	});

--- a/src/app/routes/components/HomeSections.tsx
+++ b/src/app/routes/components/HomeSections.tsx
@@ -4,8 +4,8 @@ import Button from "@/shared/components/layout/Button";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
 import { Section } from "@/shared/components/layout/Section";
 import { SectionHeading } from "@/shared/components/layout/SectionHeading";
-import { themeText } from "@/shared/lib/themeClasses";
 import { TIMING } from "@/shared/lib/constants";
+import { themeText } from "@/shared/lib/themeClasses";
 import type { NameItem, RatingData } from "@/shared/types";
 
 type HomeHeroState = "loading" | "ready" | "error";
@@ -28,6 +28,7 @@ interface TournamentBracketSectionProps {
 	ratings: Record<string, RatingData>;
 	onComplete: (ratings: Record<string, RatingData>) => void;
 	onGoToPicker: () => void;
+	onGoToAnalysis?: () => void;
 }
 
 function HeroNameWords({ state, lockedNames }: { state: HomeHeroState; lockedNames: NameItem[] }) {
@@ -137,6 +138,7 @@ export function TournamentBracketSection({
 	ratings,
 	onComplete,
 	onGoToPicker,
+	onGoToAnalysis,
 }: TournamentBracketSectionProps) {
 	return (
 		<Section
@@ -145,22 +147,46 @@ export function TournamentBracketSection({
 			padding="comfortable"
 			maxWidth="2xl"
 			separator={true}
+			fullpage={true}
 		>
-			<SectionHeading title="Bracket" subtitle="Head-to-head matchups." />
-			<Suspense fallback={<Loading variant="skeleton" height={400} />}>
-				{names && names.length > 0 ? (
-					<LazyTournament names={names} existingRatings={ratings} onComplete={onComplete} />
-				) : (
-					<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 py-12 text-center">
-						<p className="text-pretty text-sm text-muted-foreground/70">
-							Pick at least 2 names to start comparing them.
-						</p>
-						<Button variant="glass" onClick={onGoToPicker}>
-							← Back
-						</Button>
+			<div className="flex flex-col items-center justify-center min-h-[100dvh] py-12 md:py-16">
+				<div className="w-full flex flex-col items-center gap-8 md:gap-12">
+					<div>
+						<SectionHeading
+							title="Compare Names"
+							subtitle="Vote on which name you prefer in each matchup."
+						/>
 					</div>
-				)}
-			</Suspense>
+					<Suspense fallback={<Loading variant="skeleton" height={400} />}>
+						{names && names.length > 0 ? (
+							<>
+								<div className="w-full">
+									<LazyTournament names={names} existingRatings={ratings} onComplete={onComplete} />
+								</div>
+								{onGoToAnalysis && (
+									<div className="mt-auto pt-8 flex justify-center gap-4">
+										<Button variant="glass" size="lg" onClick={onGoToPicker}>
+											← Back
+										</Button>
+										<Button variant="glass" size="lg" onClick={onGoToAnalysis}>
+											See Results →
+										</Button>
+									</div>
+								)}
+							</>
+						) : (
+							<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
+								<p className="text-pretty text-sm text-muted-foreground/70">
+									Pick at least 2 names to start comparing them.
+								</p>
+								<Button variant="glass" onClick={onGoToPicker}>
+									← Back
+								</Button>
+							</div>
+						)}
+					</Suspense>
+				</div>
+			</div>
 		</Section>
 	);
 }

--- a/src/features/tournament/modes/TournamentFlow.test.tsx
+++ b/src/features/tournament/modes/TournamentFlow.test.tsx
@@ -57,8 +57,8 @@ describe("TournamentFlow responsive behavior", () => {
 
 		renderWithProviders();
 
-		const analyzeButton = screen.getByRole("button", { name: "Analyze Results" });
-		const startButton = screen.getByRole("button", { name: "Start New Tournament" });
+		const analyzeButton = screen.getByRole("button", { name: "See Results" });
+		const startButton = screen.getByRole("button", { name: "Pick Different Names" });
 		const heading = screen.getByRole("heading", {
 			name: "A victor emerges from the eternal tournament",
 		});

--- a/src/shared/components/layout/FloatingNavbar.test.tsx
+++ b/src/shared/components/layout/FloatingNavbar.test.tsx
@@ -168,7 +168,7 @@ describe("FloatingNavbar", () => {
 
 		expandNav();
 
-		expect(screen.getAllByRole("button", { name: "Pick Names" })[0]).toHaveAttribute(
+		expect(screen.getAllByRole("button", { name: "Favorites" })[0]).toHaveAttribute(
 			"aria-current",
 			"location",
 		);
@@ -201,11 +201,11 @@ describe("FloatingNavbar", () => {
 
 		expandNav();
 
-		const startButton = screen.getAllByRole("button", { name: "Start (3)" })[0];
+		const startButton = screen.getAllByRole("button", { name: "Vote (3)" })[0];
 
 		expect(startButton).toBeInTheDocument();
 		expect(startButton).toHaveClass("text-primary");
-		expect(screen.queryAllByRole("button", { name: "Pick Names" }).length).toBe(0);
+		expect(screen.queryAllByRole("button", { name: "Favorites" }).length).toBe(0);
 	});
 
 	it("shows analyze as the current destination on the analysis route", () => {
@@ -224,7 +224,7 @@ describe("FloatingNavbar", () => {
 
 		expandNav();
 
-		expect(screen.getAllByRole("button", { name: "Analyze" })[0]).toHaveAttribute(
+		expect(screen.getAllByRole("button", { name: "Results" })[0]).toHaveAttribute(
 			"aria-current",
 			"location",
 		);


### PR DESCRIPTION
🧹 **Code Health Improvement**

🎯 **What:** Extracted the inline JSX block corresponding to the tournament bracket into the `TournamentBracketSection` component within `src/app/routes/components/HomeSections.tsx`. We also added the `onGoToAnalysis` prop to `TournamentBracketSectionProps` so the layout components match accurately.
💡 **Why:** This refactoring improves the overall code health and readability of `HomeRoute.tsx` by eliminating a very long block of code that had too many responsibilities, separating the layout from the logic.
✅ **Verification:** Ensured that `pnpm test run` was executed and all 364 tests passed successfully after fixing broken selectors and UI test text assertions for the new floating navigation structure and names logic.
✨ **Result:** The component logic is much simpler to read and digest, significantly enhancing maintainability.

---
*PR created automatically by Jules for task [13260966760780469723](https://jules.google.com/task/13260966760780469723) started by @guitarbeat*

## Summary by Sourcery

Extract the tournament bracket UI in the home route into a dedicated reusable section component and align related tests and copy with the new structure and labels.

Enhancements:
- Introduce a TournamentBracketSection layout component to encapsulate the tournament comparison flow on the home page and support navigation callbacks to the picker and analysis sections.
- Adjust button labels and section headings in the tournament and navbar flows to use the updated naming (e.g., Favorites, Vote, Results).

Tests:
- Update HomeRoute, FloatingNavbar, TournamentFlow, and HomeSections tests to target the new TournamentBracketSection component and revised UI text.