### PR TITLE
fix: resolve ts-expect-error on CardNameBase disabled prop

### DIFF
--- a/src/shared/components/layout/Card/Card.tsx
+++ b/src/shared/components/layout/Card/Card.tsx
@@ -103,6 +103,7 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	liquidGlass?: boolean | GlassConfig;
 	interactive?: boolean;
 	enableTilt?: boolean;
+	disabled?: boolean;
 }
 
 const CardBase = memo(
@@ -488,7 +489,6 @@ const CardNameBase = memo(function CardName({
 					className,
 				)}
 				onClick={isInteractive ? handleInteraction : undefined}
-				// @ts-expect-error - Card props might not fully match HTML attributes
 				disabled={isInteractive ? disabled : undefined}
 				aria-pressed={isInteractive ? isSelected : undefined}
 				aria-label={getAriaLabel()}


### PR DESCRIPTION
🎯 **What:** Removed `@ts-expect-error` comment and resolved the TypeScript error by adding the `disabled` property explicitly to the `CardProps` interface in `src/shared/components/layout/Card/Card.tsx`.

💡 **Why:** `CardProps` extends `React.HTMLAttributes<HTMLDivElement>`, which doesn't natively include a `disabled` property. Adding it to the interface explicitly prevents TypeScript errors and eliminates the need for suppression comments, improving codebase health, readability, and maintainability.

✅ **Verification:**
- Ran `git diff` to verify only intended changes were made.
- Successfully passed type checking with `pnpm run lint:types`.
- Ran the specific component tests via `pnpm test run src/shared/components/layout/Card/Card.test.tsx` successfully.
- Ran the full test suite (`pnpm test run`), and verified pre-existing failures on the `main` branch.

✨ **Result:** The codebase no longer relies on `@ts-expect-error` for the `disabled` prop in the `Card` component, improving type safety without changing runtime behavior.

---
*PR created automatically by Jules for task [3698095507560446967](https://jules.google.com/task/3698095507560446967) started by @guitarbeat*