### PR TITLE
🧹 fix: replace console.error with ErrorManager in ProfileInner

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🎯 **What:** Replaced raw `console.error` calls with `ErrorManager.handleError` in `ProfileInner.tsx`.
+💡 **Why:** Using `ErrorManager` centrally handles errors and improves observability/monitoring instead of silently dropping them into the browser console. This improves maintainability and tracking for profile-related actions.
+✅ **Verification:** Verified with `git diff`, `pnpm test run`, type-checking, and linting. Only `ProfileInner.tsx` tests were rerun to ensure nothing broke. The changes were strictly imports and replacing `console.error` inside catch-blocks. Code review gave a rating of `#Correct#`.
+✨ **Result:** Better error tracking and consistent error handling within the Profile view component.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-🎯 **What:** Replaced raw `console.error` calls with `ErrorManager.handleError` in `ProfileInner.tsx`.
-💡 **Why:** Using `ErrorManager` centrally handles errors and improves observability/monitoring instead of silently dropping them into the browser console. This improves maintainability and tracking for profile-related actions.
-✅ **Verification:** Verified with `git diff`, `pnpm test run`, type-checking, and linting. Only `ProfileInner.tsx` tests were rerun to ensure nothing broke. The changes were strictly imports and replacing `console.error` inside catch-blocks. Code review gave a rating of `#Correct#`.
-✨ **Result:** Better error tracking and consistent error handling within the Profile view component.

--- a/src/shared/components/profile/ProfileInner.tsx
+++ b/src/shared/components/profile/ProfileInner.tsx
@@ -1,3 +1,4 @@
+import { ErrorManager } from "@/shared/services/errorManager";
 import { LogOut, Pencil, User } from "lucide-react";
 import { type RefObject, useEffect, useRef, useState } from "react";
 import Button from "@/shared/components/layout/Button";
@@ -10,7 +11,13 @@ interface ProfileInnerProps {
 	onLogout: () => Promise<void>;
 }
 
-function ProfileAvatar({ avatarSrc, onError }: { avatarSrc: string; onError: () => void }) {
+function ProfileAvatar({
+	avatarSrc,
+	onError,
+}: {
+	avatarSrc: string;
+	onError: () => void;
+}) {
 	return (
 		<div className="relative mb-1">
 			<div
@@ -18,7 +25,12 @@ function ProfileAvatar({ avatarSrc, onError }: { avatarSrc: string; onError: () 
 				aria-hidden="true"
 			/>
 			<div className="relative size-24 rounded-full overflow-hidden ring-2 ring-primary/30 ring-offset-2 ring-offset-card bg-muted shadow-lg">
-				<img src={avatarSrc} alt="Profile" className="size-full object-cover" onError={onError} />
+				<img
+					src={avatarSrc}
+					alt="Profile"
+					className="size-full object-cover"
+					onError={onError}
+				/>
 			</div>
 		</div>
 	);
@@ -75,7 +87,12 @@ function ProfileEditForm({
 
 			<div className="flex gap-2">
 				{isLoggedIn && (
-					<Button type="button" variant="ghost" onClick={handleCancel} className="flex-1">
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={handleCancel}
+						className="flex-1"
+					>
 						Cancel
 					</Button>
 				)}
@@ -102,7 +119,12 @@ interface ProfileViewProps {
 	handleLogout: () => void;
 }
 
-function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: ProfileViewProps) {
+function ProfileView({
+	userName,
+	isLoggingOut,
+	handleEdit,
+	handleLogout,
+}: ProfileViewProps) {
 	return (
 		<div className="w-full flex flex-col items-center gap-3 animate-in fade-in duration-200">
 			<div className="flex items-center gap-2">
@@ -117,7 +139,9 @@ function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: Profi
 				</button>
 			</div>
 
-			<p className="text-xs text-muted-foreground/80">Your preferences are saved for ranking.</p>
+			<p className="text-xs text-muted-foreground/80">
+				Your preferences are saved for ranking.
+			</p>
 
 			<button
 				type="button"
@@ -183,7 +207,7 @@ export function ProfileInner({ onLogin, onLogout }: ProfileInnerProps) {
 			}
 			setIsEditing(false);
 		} catch (err) {
-			console.error("Failed to update name:", err);
+			ErrorManager.handleError(err, "Profile update name");
 			setSaveError("We couldn't log you in right now. Try again.");
 		} finally {
 			setIsSaving(false);
@@ -196,7 +220,7 @@ export function ProfileInner({ onLogin, onLogout }: ProfileInnerProps) {
 			await onLogout();
 			setIsEditing(true);
 		} catch (err) {
-			console.error("Failed to logout:", err);
+			ErrorManager.handleError(err, "Profile logout");
 		} finally {
 			setIsLoggingOut(false);
 		}
@@ -204,7 +228,10 @@ export function ProfileInner({ onLogin, onLogout }: ProfileInnerProps) {
 
 	return (
 		<div className="flex flex-col items-center gap-5 w-full">
-			<ProfileAvatar avatarSrc={avatarSrc} onError={() => setAvatarSrc(defaultAvatar)} />
+			<ProfileAvatar
+				avatarSrc={avatarSrc}
+				onError={() => setAvatarSrc(defaultAvatar)}
+			/>
 
 			{isEditing ? (
 				<ProfileEditForm

--- a/src/shared/components/profile/ProfileInner.tsx
+++ b/src/shared/components/profile/ProfileInner.tsx
@@ -1,9 +1,9 @@
-import { ErrorManager } from "@/shared/services/errorManager";
 import { LogOut, Pencil, User } from "lucide-react";
 import { type RefObject, useEffect, useRef, useState } from "react";
 import Button from "@/shared/components/layout/Button";
 import { Input } from "@/shared/components/layout/FormPrimitives";
 import { CAT_IMAGES } from "@/shared/lib/constants";
+import { ErrorManager } from "@/shared/services/errorManager";
 import useAppStore from "@/store/appStore";
 
 interface ProfileInnerProps {
@@ -11,13 +11,7 @@ interface ProfileInnerProps {
 	onLogout: () => Promise<void>;
 }
 
-function ProfileAvatar({
-	avatarSrc,
-	onError,
-}: {
-	avatarSrc: string;
-	onError: () => void;
-}) {
+function ProfileAvatar({ avatarSrc, onError }: { avatarSrc: string; onError: () => void }) {
 	return (
 		<div className="relative mb-1">
 			<div
@@ -25,12 +19,7 @@ function ProfileAvatar({
 				aria-hidden="true"
 			/>
 			<div className="relative size-24 rounded-full overflow-hidden ring-2 ring-primary/30 ring-offset-2 ring-offset-card bg-muted shadow-lg">
-				<img
-					src={avatarSrc}
-					alt="Profile"
-					className="size-full object-cover"
-					onError={onError}
-				/>
+				<img src={avatarSrc} alt="Profile" className="size-full object-cover" onError={onError} />
 			</div>
 		</div>
 	);
@@ -87,12 +76,7 @@ function ProfileEditForm({
 
 			<div className="flex gap-2">
 				{isLoggedIn && (
-					<Button
-						type="button"
-						variant="ghost"
-						onClick={handleCancel}
-						className="flex-1"
-					>
+					<Button type="button" variant="ghost" onClick={handleCancel} className="flex-1">
 						Cancel
 					</Button>
 				)}
@@ -119,12 +103,7 @@ interface ProfileViewProps {
 	handleLogout: () => void;
 }
 
-function ProfileView({
-	userName,
-	isLoggingOut,
-	handleEdit,
-	handleLogout,
-}: ProfileViewProps) {
+function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: ProfileViewProps) {
 	return (
 		<div className="w-full flex flex-col items-center gap-3 animate-in fade-in duration-200">
 			<div className="flex items-center gap-2">
@@ -139,9 +118,7 @@ function ProfileView({
 				</button>
 			</div>
 
-			<p className="text-xs text-muted-foreground/80">
-				Your preferences are saved for ranking.
-			</p>
+			<p className="text-xs text-muted-foreground/80">Your preferences are saved for ranking.</p>
 
 			<button
 				type="button"
@@ -228,10 +205,7 @@ export function ProfileInner({ onLogin, onLogout }: ProfileInnerProps) {
 
 	return (
 		<div className="flex flex-col items-center gap-5 w-full">
-			<ProfileAvatar
-				avatarSrc={avatarSrc}
-				onError={() => setAvatarSrc(defaultAvatar)}
-			/>
+			<ProfileAvatar avatarSrc={avatarSrc} onError={() => setAvatarSrc(defaultAvatar)} />
 
 			{isEditing ? (
 				<ProfileEditForm


### PR DESCRIPTION
🎯 **What:** Replaced raw `console.error` calls with `ErrorManager.handleError` in `ProfileInner.tsx`.
💡 **Why:** Using `ErrorManager` centrally handles errors and improves observability/monitoring instead of silently dropping them into the browser console. This improves maintainability and tracking for profile-related actions.
✅ **Verification:** Verified with `git diff`, `pnpm test run`, type-checking, and linting. Only `ProfileInner.tsx` tests were rerun to ensure nothing broke. The changes were strictly imports and replacing `console.error` inside catch-blocks. Code review gave a rating of `#Correct#`.
✨ **Result:** Better error tracking and consistent error handling within the Profile view component.

---
*PR created automatically by Jules for task [16716805046688170029](https://jules.google.com/task/16716805046688170029) started by @guitarbeat*