### PR TITLE
fix: replace explicit any type with UseAudioManagerResult in TournamentHeader

### DIFF
--- a/src/features/tournament/components/TournamentHeader.tsx
+++ b/src/features/tournament/components/TournamentHeader.tsx
@@ -11,6 +11,7 @@ import {
 	VolumeX,
 	X,
 } from "lucide-react";
+import { type UseAudioManagerResult } from "../hooks/useAudioManager";
 import { getHeatTextClasses, type HeatLevel } from "../utils/heat";
 import { BracketTree } from "./BracketTree";
 
@@ -22,7 +23,7 @@ interface TournamentHeaderProps {
 	currentMatchNumber: number;
 	totalMatches: number;
 	etaMinutes: number;
-	audioManager: any;
+	audioManager: UseAudioManagerResult;
 	showCatPictures: boolean;
 	setCatPictures: (show: boolean) => void;
 	canUndo: boolean;

--- a/src/features/tournament/hooks/useAudioManager.ts
+++ b/src/features/tournament/hooks/useAudioManager.ts
@@ -14,7 +14,7 @@ import { getStorageString, isStorageAvailable, setStorageString } from "@/shared
    AUDIO MANAGER HOOK
    ========================================================================= */
 
-interface UseAudioManagerResult {
+export interface UseAudioManagerResult {
 	isMuted: boolean;
 	handleToggleMute: () => void;
 	playVoteSound: () => void;


### PR DESCRIPTION
🎯 **What:** Replaced the explicit `any` type for the `audioManager` prop in the `TournamentHeaderProps` interface with the more specific `UseAudioManagerResult` type.
💡 **Why:** This improves the maintainability and readability of the codebase by providing strict type checking for the `audioManager` prop. It eliminates a blind spot in TypeScript's static analysis, making it easier to safely refactor and utilize the audio manager's properties inside `TournamentHeader`.
✅ **Verification:** 
- The changes simply exported an existing interface (`UseAudioManagerResult`) from the hooks file and imported it in the component file, changing no runtime behavior.
- I verified this compiles correctly by running `pnpm run lint:types` and it completes successfully without regression.
- I ran the full test suite (`pnpm test run`) and confirmed that there were no new regressions. Existing failing tests on the branch were confirmed to also fail on the `main` branch.
✨ **Result:** Improved type safety and developer experience without changing application behavior.

---
*PR created automatically by Jules for task [17698205640224180608](https://jules.google.com/task/17698205640224180608) started by @guitarbeat*