### PR TITLE
🧹 refactor: replace @ts-expect-error with type-safe cast in updateSupabaseUserContext

### DIFF
--- a/src/shared/services/supabase/runtime.ts
+++ b/src/shared/services/supabase/runtime.ts
@@ -152,22 +152,22 @@ export const updateSupabaseUserContext = (
 	if (!supabaseInstance) {
 		return;
 	}
-	// @ts-expect-error - accessing internal property
-	if (supabaseInstance.rest?.headers) {
+
+	const internalClient = supabaseInstance as unknown as {
+		rest?: { headers?: Record<string, string | undefined> };
+	};
+
+	if (internalClient.rest?.headers) {
 		if (userName) {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-name"] = userName;
+			internalClient.rest.headers["x-user-name"] = userName;
 		} else {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-name"] = undefined;
+			internalClient.rest.headers["x-user-name"] = undefined;
 		}
 
 		if (userId) {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-id"] = userId;
+			internalClient.rest.headers["x-user-id"] = userId;
 		} else {
-			// @ts-expect-error - Accessing internal Supabase client headers
-			supabaseInstance.rest.headers["x-user-id"] = undefined;
+			internalClient.rest.headers["x-user-id"] = undefined;
 		}
 	}
 };


### PR DESCRIPTION
🎯 **What:** Replaced the use of `@ts-expect-error` comments in `updateSupabaseUserContext` inside `src/shared/services/supabase/runtime.ts` with a type-safe unknown-to-object cast `as unknown as { rest?: { headers?: Record<string, string | undefined> } }`.

💡 **Why:** Relying on `@ts-expect-error` to suppress type issues can hide underlying schema or interface changes. Using an explicit type assertion is safer and clearly defines the structure being accessed without polluting the codebase with compiler suppressions, improving readability and code health.

✅ **Verification:** Verified by running `pnpm run lint:types` which completed without any TypeScript errors, and by executing the full test suite via `pnpm test run` to ensure no functionality is broken. Pre-commit checks confirmed all requirements were met.

✨ **Result:** Cleaned up code health issues by properly typing an internal client structure, making the codebase cleaner and less prone to accidental regressions.

---
*PR created automatically by Jules for task [17374668828198777746](https://jules.google.com/task/17374668828198777746) started by @guitarbeat*