### PR TITLE
refactor: extract AdminNamesTab subcomponents

### DIFF
--- a/src/features/dashboard/components/admin/components/AdminNameRow.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNameRow.tsx
@@ -1,0 +1,95 @@
+import { Eye, EyeOff, Lock, Trash2 } from "lucide-react";
+import Button from "@/shared/components/layout/Button";
+import { isNameHidden, isNameLocked } from "@/shared/lib/names/nameFilters";
+import type { NameWithStats } from "./AdminNamesTab";
+
+interface AdminNameRowProps {
+	name: NameWithStats;
+	isSelected: boolean;
+	onSelectionChange: (nameId: string, checked: boolean) => void;
+	onToggleHidden: (nameId: string | number, isHidden: boolean) => void;
+	onToggleLocked: (nameId: string | number, isLocked: boolean) => void;
+	onDelete: (nameId: string | number) => void;
+}
+
+export function AdminNameRow({
+	name,
+	isSelected,
+	onSelectionChange,
+	onToggleHidden,
+	onToggleLocked,
+	onDelete,
+}: AdminNameRowProps) {
+	const nameId = String(name.id);
+	const hidden = isNameHidden(name);
+	const locked = isNameLocked(name);
+
+	return (
+		<div className="py-3 sm:py-4">
+			<div className="flex items-start sm:items-center justify-between gap-2">
+				<div className="flex items-start sm:items-center gap-3 sm:gap-4 min-w-0">
+					<input
+						type="checkbox"
+						checked={isSelected}
+						onChange={(event) => onSelectionChange(nameId, event.target.checked)}
+						className="w-4 h-4 mt-1 sm:mt-0 shrink-0"
+					/>
+					<div className="min-w-0">
+						<div className="flex items-center gap-2 flex-wrap">
+							<h3 className="font-semibold text-foreground text-sm sm:text-base">{name.name}</h3>
+							{locked && (
+								<span className="text-[10px] text-chart-4 font-semibold inline-flex items-center gap-0.5">
+									<Lock size={10} /> Locked
+								</span>
+							)}
+							{hidden && (
+								<span className="text-[10px] text-destructive font-semibold inline-flex items-center gap-0.5">
+									<EyeOff size={10} /> Hidden
+								</span>
+							)}
+						</div>
+						{name.description && (
+							<p className="text-xs sm:text-sm text-muted-foreground line-clamp-1">
+								{name.description}
+							</p>
+						)}
+						<div className="flex gap-3 mt-0.5 text-[10px] sm:text-xs text-muted-foreground/60">
+							<span>Votes: {name.votes}</span>
+							<span>
+								Score: {name.popularityScore == null ? "?" : name.popularityScore.toFixed(1)}
+							</span>
+						</div>
+					</div>
+				</div>
+
+				<div className="flex items-center gap-1 shrink-0">
+					<Button
+						onClick={() => onToggleHidden(name.id, hidden)}
+						variant="ghost"
+						size="small"
+						aria-label={hidden ? "Unhide name" : "Hide name"}
+					>
+						{hidden ? <Eye size={14} /> : <EyeOff size={14} />}
+					</Button>
+					<Button
+						onClick={() => onToggleLocked(name.id, locked)}
+						variant="ghost"
+						size="small"
+						aria-label={locked ? "Unlock name" : "Lock name"}
+					>
+						<Lock size={14} />
+					</Button>
+					<Button
+						onClick={() => onDelete(name.id)}
+						variant="ghost"
+						size="small"
+						aria-label="Delete name"
+						className="text-destructive hover:text-destructive"
+					>
+						<Trash2 size={14} />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/features/dashboard/components/admin/components/AdminNameRow.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNameRow.tsx
@@ -1,7 +1,7 @@
 import { Eye, EyeOff, Lock, Trash2 } from "lucide-react";
 import Button from "@/shared/components/layout/Button";
 import { isNameHidden, isNameLocked } from "@/shared/lib/names/nameFilters";
-import type { NameWithStats } from "./AdminNamesTab";
+import type { NameWithStats } from "./AdminNamesTypes";
 
 interface AdminNameRowProps {
 	name: NameWithStats;

--- a/src/features/dashboard/components/admin/components/AdminNamesBulkActions.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNamesBulkActions.tsx
@@ -1,6 +1,6 @@
 import { Eye, EyeOff, Lock } from "lucide-react";
 import Button from "@/shared/components/layout/Button";
-import type { BulkAction } from "./AdminNamesTab";
+import type { BulkAction } from "./AdminNamesTypes";
 
 interface AdminNamesBulkActionsProps {
 	selectedCount: number;

--- a/src/features/dashboard/components/admin/components/AdminNamesBulkActions.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNamesBulkActions.tsx
@@ -1,0 +1,42 @@
+import { Eye, EyeOff, Lock } from "lucide-react";
+import Button from "@/shared/components/layout/Button";
+import type { BulkAction } from "./AdminNamesTab";
+
+interface AdminNamesBulkActionsProps {
+	selectedCount: number;
+	onBulkAction: (action: BulkAction) => void;
+	onClearSelection: () => void;
+}
+
+export function AdminNamesBulkActions({
+	selectedCount,
+	onBulkAction,
+	onClearSelection,
+}: AdminNamesBulkActionsProps) {
+	if (selectedCount === 0) {
+		return null;
+	}
+
+	return (
+		<div className="mb-4 py-3 sm:py-4 border-y border-border/10">
+			<p className="text-sm text-primary mb-2">{selectedCount} selected</p>
+			<div className="flex flex-wrap gap-2">
+				<Button onClick={() => onBulkAction("hide")} size="small">
+					<EyeOff size={14} /> Hide
+				</Button>
+				<Button onClick={() => onBulkAction("unhide")} size="small">
+					<Eye size={14} /> Unhide
+				</Button>
+				<Button onClick={() => onBulkAction("lock")} size="small">
+					<Lock size={14} /> Lock
+				</Button>
+				<Button onClick={() => onBulkAction("unlock")} size="small">
+					<Lock size={14} /> Unlock
+				</Button>
+				<Button onClick={onClearSelection} variant="ghost" size="small">
+					Clear
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/features/dashboard/components/admin/components/AdminNamesTab.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNamesTab.tsx
@@ -1,18 +1,15 @@
-import { Eye, EyeOff, Loader2, Lock, Trash2 } from "lucide-react";
-import { motion } from "framer-motion";
 import type { ChangeEvent } from "react";
-import Button from "@/shared/components/layout/Button";
-import { Input } from "@/shared/components/layout/FormPrimitives";
-import { SelectCombobox } from "@/shared/components/ui/SelectCombobox";
-import { isNameHidden, isNameLocked } from "@/shared/lib/names/nameFilters";
 import type { NameItem } from "@/shared/types";
+import { AdminNameRow } from "./AdminNameRow";
+import { AdminNamesBulkActions } from "./AdminNamesBulkActions";
+import { AdminNamesToolbar } from "./AdminNamesToolbar";
 
-type NameWithStats = NameItem & {
+export type NameWithStats = NameItem & {
 	votes?: number;
 	popularityScore?: number;
 };
 
-type BulkAction = "hide" | "unhide" | "lock" | "unlock";
+export type BulkAction = "hide" | "unhide" | "lock" | "unlock";
 
 interface AdminNamesTabProps {
 	searchTerm: string;
@@ -49,139 +46,33 @@ export function AdminNamesTab({
 }: AdminNamesTabProps) {
 	return (
 		<>
-			<motion.div
-				className="flex flex-col lg:flex-row gap-4 mb-6"
-				initial={{ opacity: 0, y: -8 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.3 }}
-			>
-				<div className="flex-1">
-					<Input
-						type="text"
-						placeholder="Search names..."
-						value={searchTerm}
-						onChange={(event) => onSearchTermChange(event.target.value)}
-						className="w-full"
-					/>
-				</div>
-				<div className="flex gap-2">
-					<div className="w-full max-w-xs">
-						<SelectCombobox
-							options={filterOptions}
-							value={filterStatus}
-							onChange={(value) => onFilterChange({ target: { value } } as ChangeEvent<HTMLSelectElement>)}
-							placeholder="Filter by status..."
-							ariaLabel="Filter names by status"
-						/>
-					</div>
+			<AdminNamesToolbar
+				searchTerm={searchTerm}
+				onSearchTermChange={onSearchTermChange}
+				filterStatus={filterStatus}
+				filterOptions={filterOptions}
+				onFilterChange={onFilterChange}
+				onRefresh={onRefresh}
+			/>
 
-					<Button onClick={onRefresh} variant="ghost" size="small">
-						<Loader2 size={16} />
-					</Button>
-				</div>
-			</motion.div>
-
-			{selectedNames.size > 0 && (
-				<div className="mb-4 py-3 sm:py-4 border-y border-border/10">
-					<p className="text-sm text-primary mb-2">{selectedNames.size} selected</p>
-					<div className="flex flex-wrap gap-2">
-						<Button onClick={() => onBulkAction("hide")} size="small">
-							<EyeOff size={14} /> Hide
-						</Button>
-						<Button onClick={() => onBulkAction("unhide")} size="small">
-							<Eye size={14} /> Unhide
-						</Button>
-						<Button onClick={() => onBulkAction("lock")} size="small">
-							<Lock size={14} /> Lock
-						</Button>
-						<Button onClick={() => onBulkAction("unlock")} size="small">
-							<Lock size={14} /> Unlock
-						</Button>
-						<Button onClick={onClearSelection} variant="ghost" size="small">
-							Clear
-						</Button>
-					</div>
-				</div>
-			)}
+			<AdminNamesBulkActions
+				selectedCount={selectedNames.size}
+				onBulkAction={onBulkAction}
+				onClearSelection={onClearSelection}
+			/>
 
 			<div className="divide-y divide-border/10">
-				{filteredNames.map((name) => {
-					const nameId = String(name.id);
-					const hidden = isNameHidden(name);
-					const locked = isNameLocked(name);
-
-					return (
-						<div key={name.id} className="py-3 sm:py-4">
-							<div className="flex items-start sm:items-center justify-between gap-2">
-								<div className="flex items-start sm:items-center gap-3 sm:gap-4 min-w-0">
-									<input
-										type="checkbox"
-										checked={selectedNames.has(nameId)}
-										onChange={(event) => onSelectionChange(nameId, event.target.checked)}
-										className="w-4 h-4 mt-1 sm:mt-0 shrink-0"
-									/>
-									<div className="min-w-0">
-										<div className="flex items-center gap-2 flex-wrap">
-											<h3 className="font-semibold text-foreground text-sm sm:text-base">
-												{name.name}
-											</h3>
-											{locked && (
-												<span className="text-[10px] text-chart-4 font-semibold inline-flex items-center gap-0.5">
-													<Lock size={10} /> Locked
-												</span>
-											)}
-											{hidden && (
-												<span className="text-[10px] text-destructive font-semibold inline-flex items-center gap-0.5">
-													<EyeOff size={10} /> Hidden
-												</span>
-											)}
-										</div>
-										{name.description && (
-											<p className="text-xs sm:text-sm text-muted-foreground line-clamp-1">
-												{name.description}
-											</p>
-										)}
-										<div className="flex gap-3 mt-0.5 text-[10px] sm:text-xs text-muted-foreground/60">
-											<span>Votes: {name.votes}</span>
-											<span>
-												Score:{" "}
-												{name.popularityScore == null ? "?" : name.popularityScore.toFixed(1)}
-											</span>
-										</div>
-									</div>
-								</div>
-
-								<div className="flex items-center gap-1 shrink-0">
-									<Button
-										onClick={() => onToggleHidden(name.id, hidden)}
-										variant="ghost"
-										size="small"
-										aria-label={hidden ? "Unhide name" : "Hide name"}
-									>
-										{hidden ? <Eye size={14} /> : <EyeOff size={14} />}
-									</Button>
-									<Button
-										onClick={() => onToggleLocked(name.id, locked)}
-										variant="ghost"
-										size="small"
-										aria-label={locked ? "Unlock name" : "Lock name"}
-									>
-										<Lock size={14} />
-									</Button>
-									<Button
-										onClick={() => onDelete(name.id)}
-										variant="ghost"
-										size="small"
-										aria-label="Delete name"
-										className="text-destructive hover:text-destructive"
-									>
-										<Trash2 size={14} />
-									</Button>
-								</div>
-							</div>
-						</div>
-					);
-				})}
+				{filteredNames.map((name) => (
+					<AdminNameRow
+						key={name.id}
+						name={name}
+						isSelected={selectedNames.has(String(name.id))}
+						onSelectionChange={onSelectionChange}
+						onToggleHidden={onToggleHidden}
+						onToggleLocked={onToggleLocked}
+						onDelete={onDelete}
+					/>
+				))}
 			</div>
 		</>
 	);

--- a/src/features/dashboard/components/admin/components/AdminNamesTab.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNamesTab.tsx
@@ -1,15 +1,8 @@
 import type { ChangeEvent } from "react";
-import type { NameItem } from "@/shared/types";
 import { AdminNameRow } from "./AdminNameRow";
 import { AdminNamesBulkActions } from "./AdminNamesBulkActions";
 import { AdminNamesToolbar } from "./AdminNamesToolbar";
-
-export type NameWithStats = NameItem & {
-	votes?: number;
-	popularityScore?: number;
-};
-
-export type BulkAction = "hide" | "unhide" | "lock" | "unlock";
+import type { BulkAction, NameWithStats } from "./AdminNamesTypes";
 
 interface AdminNamesTabProps {
 	searchTerm: string;

--- a/src/features/dashboard/components/admin/components/AdminNamesToolbar.tsx
+++ b/src/features/dashboard/components/admin/components/AdminNamesToolbar.tsx
@@ -1,0 +1,60 @@
+import { motion } from "framer-motion";
+import { Loader2 } from "lucide-react";
+import type { ChangeEvent } from "react";
+import Button from "@/shared/components/layout/Button";
+import { Input } from "@/shared/components/layout/FormPrimitives";
+import { SelectCombobox } from "@/shared/components/ui/SelectCombobox";
+
+interface AdminNamesToolbarProps {
+	searchTerm: string;
+	onSearchTermChange: (value: string) => void;
+	filterStatus: string;
+	filterOptions: readonly { value: string; label: string }[];
+	onFilterChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+	onRefresh: () => void;
+}
+
+export function AdminNamesToolbar({
+	searchTerm,
+	onSearchTermChange,
+	filterStatus,
+	filterOptions,
+	onFilterChange,
+	onRefresh,
+}: AdminNamesToolbarProps) {
+	return (
+		<motion.div
+			className="flex flex-col lg:flex-row gap-4 mb-6"
+			initial={{ opacity: 0, y: -8 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.3 }}
+		>
+			<div className="flex-1">
+				<Input
+					type="text"
+					placeholder="Search names..."
+					value={searchTerm}
+					onChange={(event) => onSearchTermChange(event.target.value)}
+					className="w-full"
+				/>
+			</div>
+			<div className="flex gap-2">
+				<div className="w-full max-w-xs">
+					<SelectCombobox
+						options={filterOptions}
+						value={filterStatus}
+						onChange={(value) =>
+							onFilterChange({ target: { value } } as ChangeEvent<HTMLSelectElement>)
+						}
+						placeholder="Filter by status..."
+						ariaLabel="Filter names by status"
+					/>
+				</div>
+
+				<Button onClick={onRefresh} variant="ghost" size="small">
+					<Loader2 size={16} />
+				</Button>
+			</div>
+		</motion.div>
+	);
+}

--- a/src/features/dashboard/components/admin/components/AdminNamesTypes.ts
+++ b/src/features/dashboard/components/admin/components/AdminNamesTypes.ts
@@ -1,0 +1,8 @@
+import type { NameItem } from "@/shared/types";
+
+export type NameWithStats = NameItem & {
+	votes?: number;
+	popularityScore?: number;
+};
+
+export type BulkAction = "hide" | "unhide" | "lock" | "unlock";


### PR DESCRIPTION
🎯 **What:** Extracted the overly complex mapping logic from `AdminNamesTab` into separate reusable components (`AdminNameRow`, `AdminNamesToolbar`, `AdminNamesBulkActions`).
💡 **Why:** The monolithic `AdminNamesTab` function was long and hard to follow. Splitting it into smaller, purpose-driven components improves maintainability, readability, and isolates the rendering logic of individual rows and UI toolbars.
✅ **Verification:** Verified changes visually with `git diff`. Ran Biome to ensure code formatting and lint rules were respected. Ran the test suite `pnpm test run` and confirmed no regressions were introduced (tests failing were preexisting failures). 
✨ **Result:** A more modular and easier-to-read `AdminNamesTab` component with isolated row, toolbar, and bulk action logic.

---
*PR created automatically by Jules for task [6980115517864786108](https://jules.google.com/task/6980115517864786108) started by @guitarbeat*