### PR TITLE
feat: add missing aria-labels to buttons in NameSelector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Missing accessibility attributes in standard navigation layouts
+**Learning:** Found that custom layout panels containing toggles, filters, and dynamic inline controls inside `NameSelector.tsx` lacked explicitly provided `aria-label` tags for screen-readers, even though they contained readable content or clear icons. Text-bearing buttons like "Clear search" often omit specific ARIA labels, which limits explicit context when read in isolation.
+**Action:** Always verify complex or floating UI components (like dashboards, admin controls, or toggleable panels) and manually apply `aria-label` traits to explicit interactive actions (e.g. toggle states and specific actions that don't rely entirely on a standard UI component template).

--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -629,6 +629,7 @@ export function NameSelector() {
 																				? "text-muted-foreground cursor-not-allowed"
 																				: "text-warning hover:text-warning/80 hover:scale-105 active:scale-95"
 																		}`}
+																		aria-label="Toggle hidden status"
 																	>
 																		{togglingHidden.has(nameItem.id) ? (
 																			<>
@@ -892,6 +893,7 @@ export function NameSelector() {
 									}}
 									aria-expanded={hiddenPanel.isCollapsed ? "false" : "true"}
 									aria-controls="hidden-names-panel"
+									aria-label="Toggle archived names panel"
 									className="w-full flex flex-wrap items-center justify-between gap-2 sm:gap-3"
 								>
 									<div className="flex items-center gap-2">
@@ -940,8 +942,8 @@ export function NameSelector() {
 								<div className="mt-4">
 									{isSwipeMode && (
 										<p className="mb-3 text-sm leading-relaxed text-muted-foreground/75">
-											Archived names stay out of the swipe deck, but you can still inspect and select
-											them here without leaving swipe mode.
+											Archived names stay out of the swipe deck, but you can still inspect and
+											select them here without leaving swipe mode.
 										</p>
 									)}
 
@@ -964,6 +966,7 @@ export function NameSelector() {
 														setHiddenRenderCount(24);
 													}}
 													className="px-3 py-2 border border-border/10 bg-foreground/5 text-xs text-foreground/80 hover:bg-foreground/10"
+													aria-label="Clear search"
 												>
 													Clear search
 												</button>
@@ -976,6 +979,7 @@ export function NameSelector() {
 														? "bg-primary/20 border-primary/40 text-foreground"
 														: "bg-foreground/5 border-border/10 text-foreground/80"
 												}`}
+												aria-label="Toggle selected only"
 											>
 												Selected only
 											</button>
@@ -1076,6 +1080,7 @@ export function NameSelector() {
 																		? "opacity-50 cursor-not-allowed"
 																		: ""
 																}`}
+																aria-label="Toggle hidden status"
 															>
 																{togglingHidden.has(nameItem.id) ? (
 																	<div className="flex items-center justify-center gap-1">


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the "Archived Names" toggle, "Clear search", "Selected only" toggles, and the admin "Toggle hidden" actions inside `NameSelector.tsx`.
🎯 **Why:** To improve accessibility for screen readers navigating interactive elements that previously lacked explicit semantic meaning when focused.
♿ **Accessibility:** Increases screen reader comprehension when jumping through form actions and interactive panels. Also recorded this as a key UX learning in Palette's journal.

---
*PR created automatically by Jules for task [5492307272115017439](https://jules.google.com/task/5492307272115017439) started by @guitarbeat*