### PR TITLE
feat: group and animate home page section navigation buttons

### DIFF
--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -12,6 +12,7 @@ import { SectionHeading } from "@/shared/components/layout/SectionHeading";
 import { useSectionScroll } from "@/shared/hooks/useSectionScroll";
 import { getLockedNames } from "@/shared/lib/names/nameFilters";
 import useAppStore from "@/store/appStore";
+import { MagicNav } from "./components/ui/MagicNav";
 
 const LazyTournament = lazy(() => import("@/features/tournament/Tournament"));
 
@@ -73,14 +74,12 @@ export default function HomeRoute() {
 								<TournamentFlow />
 							</Suspense>
 						</div>
-						<div className="mt-auto pt-8 flex justify-center gap-4">
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("")}>
-								← Back
-							</Button>
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								Compare →
-							</Button>
-						</div>
+						<MagicNav
+							actions={[
+								{ label: "← Back", onClick: () => scrollToSection("") },
+								{ label: "Compare →", onClick: () => scrollToSection("tournament") },
+							]}
+						/>
 					</div>
 				</div>
 			</Section>
@@ -114,14 +113,12 @@ export default function HomeRoute() {
 											}}
 										/>
 									</div>
-									<div className="mt-auto pt-8 flex justify-center gap-4">
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-											← Back
-										</Button>
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
-											See Results →
-										</Button>
-									</div>
+									<MagicNav
+										actions={[
+											{ label: "← Back", onClick: () => scrollToSection("pick") },
+											{ label: "See Results →", onClick: () => scrollToSection("analysis") },
+										]}
+									/>
 								</>
 							) : (
 								<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
@@ -167,14 +164,12 @@ export default function HomeRoute() {
 								</ErrorBoundary>
 							</Suspense>
 						</div>
-						<div className="mt-auto pt-8 flex justify-center gap-4">
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								← Back
-							</Button>
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-								Pick Different Names
-							</Button>
-						</div>
+						<MagicNav
+							actions={[
+								{ label: "← Back", onClick: () => scrollToSection("tournament") },
+								{ label: "Pick Different Names", onClick: () => scrollToSection("pick") },
+							]}
+						/>
 					</div>
 				</div>
 			</Section>

--- a/src/app/routes/components/ui/MagicNav.tsx
+++ b/src/app/routes/components/ui/MagicNav.tsx
@@ -1,0 +1,44 @@
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+import Button from "@/shared/components/layout/Button";
+import { TIMING } from "@/shared/lib/constants";
+
+export interface MagicNavAction {
+	label: ReactNode;
+	onClick: () => void;
+	variant?: "default" | "glass" | "outline" | "ghost" | "danger" | "success" | "warning";
+}
+
+interface MagicNavProps {
+	actions: MagicNavAction[];
+}
+
+export function MagicNav({ actions }: MagicNavProps) {
+	return (
+		<motion.div
+			initial={{ opacity: 0, y: 20 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: TIMING.MOTION_NORMAL, ease: TIMING.MOTION_EASING }}
+			className="mt-auto pt-8 flex justify-center w-full"
+		>
+			<div className="relative flex items-center gap-2 p-1.5 rounded-full bg-foreground/5 backdrop-blur-sm border border-foreground/10 shadow-lg shadow-black/5 group hover:shadow-black/10 transition-shadow">
+				{actions.map((action, i) => (
+					<motion.div
+						key={`nav-action-${i}`}
+						whileHover={{ scale: 1.05 }}
+						whileTap={{ scale: 0.95 }}
+					>
+						<Button
+							variant={action.variant ?? "glass"}
+							size="lg"
+							onClick={action.onClick}
+							className={`rounded-full px-6 transition-colors duration-300 ${action.variant ? "" : "hover:bg-foreground/10"}`}
+						>
+							{action.label}
+						</Button>
+					</motion.div>
+				))}
+			</div>
+		</motion.div>
+	);
+}

--- a/src/shared/components/ui/NavbarModals.tsx
+++ b/src/shared/components/ui/NavbarModals.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
-import { Modal } from "@/shared/components/layout/Modal";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
+import { Modal } from "@/shared/components/layout/Modal";
 
 const LazyProfileInner = lazy(() =>
 	import("@/shared/components/profile/ProfileInner").then((module) => ({

--- a/src/shared/components/ui/SegmentedControl.tsx
+++ b/src/shared/components/ui/SegmentedControl.tsx
@@ -71,8 +71,8 @@ export function SegmentedControl<T extends string = string>({
 					className={`relative flex-1 ${sizeStyles.button} text-foreground/70 transition-colors z-10 ${
 						value === option.value ? "text-foreground font-semibold" : ""
 					} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:text-foreground/90"}`}
-					whileHover={!disabled ? { scale: 1.02 } : {}}
-					whileTap={!disabled ? { scale: 0.98 } : {}}
+					whileHover={disabled ? {} : { scale: 1.02 }}
+					whileTap={disabled ? {} : { scale: 0.98 }}
 				>
 					<div className="flex items-center justify-center gap-1.5">
 						{option.icon && <span className="flex items-center justify-center">{option.icon}</span>}

--- a/src/shared/components/ui/SelectCombobox.tsx
+++ b/src/shared/components/ui/SelectCombobox.tsx
@@ -1,6 +1,6 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown, Search, X } from "lucide-react";
 import { type ChangeEvent, useCallback, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 
 interface SelectComboboxOption {
 	value: string;
@@ -60,11 +60,9 @@ export function SelectCombobox({
 					isOpen ? "border-primary/40 ring-2 ring-primary/10" : "hover:border-border/40"
 				} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
 				whileHover={!disabled && !isOpen ? { borderColor: "var(--color-border)" } : {}}
-				whileTap={!disabled ? { scale: 0.98 } : {}}
+				whileTap={disabled ? {} : { scale: 0.98 }}
 			>
-				<span className="truncate text-foreground/80">
-					{selectedOption?.label || placeholder}
-				</span>
+				<span className="truncate text-foreground/80">{selectedOption?.label || placeholder}</span>
 				<motion.div
 					animate={{ rotate: isOpen ? 180 : 0 }}
 					transition={{ duration: 0.2 }}
@@ -91,13 +89,11 @@ export function SelectCombobox({
 								<div className="relative flex items-center">
 									<Search size={14} className="absolute left-2.5 text-foreground/40" />
 									<input
-										autoFocus
+										autoFocus={true}
 										type="text"
 										placeholder="Search..."
 										value={searchTerm}
-										onChange={(e: ChangeEvent<HTMLInputElement>) =>
-											setSearchTerm(e.target.value)
-										}
+										onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
 										onClick={(e) => e.stopPropagation()}
 										className="w-full pl-8 pr-3 py-1.5 text-xs bg-muted border border-border/20 rounded text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
 									/>

--- a/src/shared/hooks/useSectionScroll.ts
+++ b/src/shared/hooks/useSectionScroll.ts
@@ -6,7 +6,9 @@ export function useSectionScroll() {
 	const pendingScrollRef = useRef<number | null>(null);
 
 	const clearPendingScroll = useCallback(() => {
-		if (pendingScrollRef.current === null) return;
+		if (pendingScrollRef.current === null) {
+			return;
+		}
 		window.clearTimeout(pendingScrollRef.current);
 		pendingScrollRef.current = null;
 	}, []);


### PR DESCRIPTION
Refactored the multiple `← Back` and `Next →` navigation button pairs scattered across `<HomeRoute>`'s sections into a single, centralized `MagicNav` component. The new component uses `framer-motion` to provide a playful, animated toggle/pill interaction group, fulfilling the user's request to "Make inputs fun. Make toggle/slider playful, magic to touch."

- Created `src/app/routes/components/ui/MagicNav.tsx`.
- Updated `src/app/routes/HomeRoute.tsx` to utilize the new component.
- Verified changes visually and via existing tests.

---
*PR created automatically by Jules for task [14056831768320291829](https://jules.google.com/task/14056831768320291829) started by @guitarbeat*

## Summary by Sourcery

Centralize home page section navigation into a reusable animated navigation component.

New Features:
- Introduce a MagicNav UI component providing an animated grouped navigation control for section transitions on the home page.

Enhancements:
- Refactor HomeRoute to replace repeated back/next button pairs with the shared MagicNav component for consistent styling and behavior.