### PR TITLE
feat: add accessibility attributes to admin tab nav

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Admin Tab Navigation
+**Learning:** Adding the `role="tablist"` to standard horizontal flex containers and `role="tab"` + `aria-selected` to child buttons significantly improves navigation clarity for screen readers without altering the visual presentation in custom components like AdminTabNav.
+**Action:** Always verify custom tab navigation implementations have correct ARIA roles when refactoring similar patterns across the application.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,16 @@
+1. **Analyze AdminTabNav Component**
+   - Review `src/features/dashboard/components/admin/components/AdminTabNav.tsx`.
+   - The `AdminTabNav` component maps over tabs array and generates `<button>` elements for navigation.
+   - It is missing accessibility attributes: `role="tablist"` on the container and `role="tab"` and `aria-selected` on the buttons.
+
+2. **Implement Accessibility Enhancements**
+   - Add `role="tablist"` to the container `<div>`.
+   - Add `role="tab"` to each `<button>`.
+   - Add `aria-selected={activeTab === tab.id}` to each `<button>`.
+
+3. **Complete pre commit steps**
+   - Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+
+4. **Verify the Changes**
+   - Use `git diff` to confirm the changes.
+   - Run tests `pnpm run test` to make sure there's no regression.

--- a/src/features/dashboard/components/admin/components/AdminTabNav.tsx
+++ b/src/features/dashboard/components/admin/components/AdminTabNav.tsx
@@ -6,10 +6,15 @@ export function AdminTabNav<TTab extends string>({
 	onTabChange,
 }: AdminTabNavProps<TTab>) {
 	return (
-		<div className="flex gap-1 sm:gap-2 mb-4 sm:mb-6 border-b border-border/10 overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
+		<div
+			className="flex gap-1 sm:gap-2 mb-4 sm:mb-6 border-b border-border/10 overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0"
+			role="tablist"
+		>
 			{tabs.map((tab) => (
 				<button
 					key={tab.id}
+					role="tab"
+					aria-selected={activeTab === tab.id}
 					onClick={() => onTabChange(tab.id)}
 					className={`px-3 sm:px-4 py-2 font-medium text-sm whitespace-nowrap transition-colors ${
 						activeTab === tab.id

--- a/src/shared/components/ui/NavbarModals.tsx
+++ b/src/shared/components/ui/NavbarModals.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
-import { Modal } from "@/shared/components/layout/Modal";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
+import { Modal } from "@/shared/components/layout/Modal";
 
 const LazyProfileInner = lazy(() =>
 	import("@/shared/components/profile/ProfileInner").then((module) => ({

--- a/src/shared/components/ui/SegmentedControl.tsx
+++ b/src/shared/components/ui/SegmentedControl.tsx
@@ -71,8 +71,8 @@ export function SegmentedControl<T extends string = string>({
 					className={`relative flex-1 ${sizeStyles.button} text-foreground/70 transition-colors z-10 ${
 						value === option.value ? "text-foreground font-semibold" : ""
 					} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:text-foreground/90"}`}
-					whileHover={!disabled ? { scale: 1.02 } : {}}
-					whileTap={!disabled ? { scale: 0.98 } : {}}
+					whileHover={disabled ? {} : { scale: 1.02 }}
+					whileTap={disabled ? {} : { scale: 0.98 }}
 				>
 					<div className="flex items-center justify-center gap-1.5">
 						{option.icon && <span className="flex items-center justify-center">{option.icon}</span>}

--- a/src/shared/components/ui/SelectCombobox.tsx
+++ b/src/shared/components/ui/SelectCombobox.tsx
@@ -1,6 +1,6 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown, Search, X } from "lucide-react";
 import { type ChangeEvent, useCallback, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 
 interface SelectComboboxOption {
 	value: string;
@@ -60,11 +60,9 @@ export function SelectCombobox({
 					isOpen ? "border-primary/40 ring-2 ring-primary/10" : "hover:border-border/40"
 				} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
 				whileHover={!disabled && !isOpen ? { borderColor: "var(--color-border)" } : {}}
-				whileTap={!disabled ? { scale: 0.98 } : {}}
+				whileTap={disabled ? {} : { scale: 0.98 }}
 			>
-				<span className="truncate text-foreground/80">
-					{selectedOption?.label || placeholder}
-				</span>
+				<span className="truncate text-foreground/80">{selectedOption?.label || placeholder}</span>
 				<motion.div
 					animate={{ rotate: isOpen ? 180 : 0 }}
 					transition={{ duration: 0.2 }}
@@ -91,13 +89,11 @@ export function SelectCombobox({
 								<div className="relative flex items-center">
 									<Search size={14} className="absolute left-2.5 text-foreground/40" />
 									<input
-										autoFocus
+										autoFocus={true}
 										type="text"
 										placeholder="Search..."
 										value={searchTerm}
-										onChange={(e: ChangeEvent<HTMLInputElement>) =>
-											setSearchTerm(e.target.value)
-										}
+										onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
 										onClick={(e) => e.stopPropagation()}
 										className="w-full pl-8 pr-3 py-1.5 text-xs bg-muted border border-border/20 rounded text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
 									/>

--- a/src/shared/hooks/useSectionScroll.ts
+++ b/src/shared/hooks/useSectionScroll.ts
@@ -6,7 +6,9 @@ export function useSectionScroll() {
 	const pendingScrollRef = useRef<number | null>(null);
 
 	const clearPendingScroll = useCallback(() => {
-		if (pendingScrollRef.current === null) return;
+		if (pendingScrollRef.current === null) {
+			return;
+		}
 		window.clearTimeout(pendingScrollRef.current);
 		pendingScrollRef.current = null;
 	}, []);


### PR DESCRIPTION
**What:** Added correct ARIA roles and attributes to the `AdminTabNav` component.
**Why:** The custom tab navigation was missing essential accessibility semantics, meaning screen readers would read it as a list of independent buttons rather than a coherent tab interface.
**Accessibility:** Added `role="tablist"` to the container, `role="tab"` to each button, and `aria-selected` to indicate the active state, significantly improving keyboard and screen reader usability without altering visual design.

---
*PR created automatically by Jules for task [8604218856593655651](https://jules.google.com/task/8604218856593655651) started by @guitarbeat*

## Summary by Sourcery

Improve accessibility of the admin dashboard tab navigation and perform minor UI and code cleanups.

New Features:
- Add ARIA tab semantics to the AdminTabNav component to expose it as a proper tab interface to assistive technologies.

Enhancements:
- Adjust motion interaction props and conditional expressions in shared UI components for clearer disabled handling and consistency.
- Tidy imports and control-flow formatting in shared components and hooks for readability.

Documentation:
- Add internal planning and learning notes documenting the accessibility changes and guidance for future tab navigation implementations.

Chores:
- Add a task-specific plan file and palette entry under the Jules tooling directory for this change.