### PR TITLE
feat: add aria roles to admin tab navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-17 - Tab Navigation Accessibility
+**Learning:** AdminTabNav custom tab button mapping required explicit ARIA roles (tablist, tab, aria-selected) to communicate semantics to screen readers.
+**Action:** Ensure custom mapped tabs apply proper accessibility markup.

--- a/src/features/dashboard/components/admin/components/AdminTabNav.tsx
+++ b/src/features/dashboard/components/admin/components/AdminTabNav.tsx
@@ -6,11 +6,16 @@ export function AdminTabNav<TTab extends string>({
 	onTabChange,
 }: AdminTabNavProps<TTab>) {
 	return (
-		<div className="flex gap-1 sm:gap-2 mb-4 sm:mb-6 border-b border-border/10 overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
+		<div
+			className="flex gap-1 sm:gap-2 mb-4 sm:mb-6 border-b border-border/10 overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0"
+			role="tablist"
+		>
 			{tabs.map((tab) => (
 				<button
 					key={tab.id}
 					onClick={() => onTabChange(tab.id)}
+					role="tab"
+					aria-selected={activeTab === tab.id}
 					className={`px-3 sm:px-4 py-2 font-medium text-sm whitespace-nowrap transition-colors ${
 						activeTab === tab.id
 							? "text-foreground border-b-2 border-primary"

--- a/src/shared/components/ui/NavbarModals.tsx
+++ b/src/shared/components/ui/NavbarModals.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
-import { Modal } from "@/shared/components/layout/Modal";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
+import { Modal } from "@/shared/components/layout/Modal";
 
 const LazyProfileInner = lazy(() =>
 	import("@/shared/components/profile/ProfileInner").then((module) => ({

--- a/src/shared/components/ui/SegmentedControl.tsx
+++ b/src/shared/components/ui/SegmentedControl.tsx
@@ -71,8 +71,8 @@ export function SegmentedControl<T extends string = string>({
 					className={`relative flex-1 ${sizeStyles.button} text-foreground/70 transition-colors z-10 ${
 						value === option.value ? "text-foreground font-semibold" : ""
 					} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:text-foreground/90"}`}
-					whileHover={!disabled ? { scale: 1.02 } : {}}
-					whileTap={!disabled ? { scale: 0.98 } : {}}
+					whileHover={disabled ? {} : { scale: 1.02 }}
+					whileTap={disabled ? {} : { scale: 0.98 }}
 				>
 					<div className="flex items-center justify-center gap-1.5">
 						{option.icon && <span className="flex items-center justify-center">{option.icon}</span>}

--- a/src/shared/components/ui/SelectCombobox.tsx
+++ b/src/shared/components/ui/SelectCombobox.tsx
@@ -1,6 +1,6 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown, Search, X } from "lucide-react";
 import { type ChangeEvent, useCallback, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 
 interface SelectComboboxOption {
 	value: string;
@@ -60,11 +60,9 @@ export function SelectCombobox({
 					isOpen ? "border-primary/40 ring-2 ring-primary/10" : "hover:border-border/40"
 				} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
 				whileHover={!disabled && !isOpen ? { borderColor: "var(--color-border)" } : {}}
-				whileTap={!disabled ? { scale: 0.98 } : {}}
+				whileTap={disabled ? {} : { scale: 0.98 }}
 			>
-				<span className="truncate text-foreground/80">
-					{selectedOption?.label || placeholder}
-				</span>
+				<span className="truncate text-foreground/80">{selectedOption?.label || placeholder}</span>
 				<motion.div
 					animate={{ rotate: isOpen ? 180 : 0 }}
 					transition={{ duration: 0.2 }}
@@ -91,13 +89,11 @@ export function SelectCombobox({
 								<div className="relative flex items-center">
 									<Search size={14} className="absolute left-2.5 text-foreground/40" />
 									<input
-										autoFocus
+										autoFocus={true}
 										type="text"
 										placeholder="Search..."
 										value={searchTerm}
-										onChange={(e: ChangeEvent<HTMLInputElement>) =>
-											setSearchTerm(e.target.value)
-										}
+										onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
 										onClick={(e) => e.stopPropagation()}
 										className="w-full pl-8 pr-3 py-1.5 text-xs bg-muted border border-border/20 rounded text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
 									/>

--- a/src/shared/hooks/useSectionScroll.ts
+++ b/src/shared/hooks/useSectionScroll.ts
@@ -6,7 +6,9 @@ export function useSectionScroll() {
 	const pendingScrollRef = useRef<number | null>(null);
 
 	const clearPendingScroll = useCallback(() => {
-		if (pendingScrollRef.current === null) return;
+		if (pendingScrollRef.current === null) {
+			return;
+		}
 		window.clearTimeout(pendingScrollRef.current);
 		pendingScrollRef.current = null;
 	}, []);


### PR DESCRIPTION
💡 What: Added standard ARIA roles (`role="tablist"` and `role="tab"`) alongside `aria-selected` attributes to the custom tab buttons in `AdminTabNav.tsx`. Logged the learning pattern in Palette's journal.
🎯 Why: To improve screen reader navigation and clearly announce the active tab in the admin dashboard, enhancing the user experience for users with assistive technologies.
♿ Accessibility: Fixes missing semantic roles for custom tab implementations, transforming generic buttons into a well-defined `tablist` group.

---
*PR created automatically by Jules for task [8440999384970728593](https://jules.google.com/task/8440999384970728593) started by @guitarbeat*

## Summary by Sourcery

Add ARIA semantics to the admin dashboard tab navigation for improved accessibility.

New Features:
- Expose admin tab navigation as a semantic tablist with individual tabs and selected state for assistive technologies.

Documentation:
- Record the ARIA tab navigation accessibility pattern in the Palette journal for future reference.