### PR TITLE
feat: group layout toggle into contextual magic component

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,14 @@
+1. **Create MagicToggle component**
+   - Use `write_file` to create `src/shared/components/ui/MagicToggle.tsx` with a playful framer-motion toggle for the layout mode.
+2. **Update NameSelector to use MagicToggle**
+   - Use `replace_with_git_merge_diff` on `src/features/tournament/components/NameSelector.tsx` to add `MagicToggle` for the Swipe vs Grid layout, moving it to a contextual location at the top of the selector.
+3. **Prune redundant buttons from HomeRoute**
+   - Use `replace_with_git_merge_diff` on `src/app/routes/HomeRoute.tsx` to rip out the dead "Back" and "Compare" buttons at the bottom of the page sections since `FloatingNavbar` handles this better.
+4. **Prune layout-mode from FloatingNavbar**
+   - Use `replace_with_git_merge_diff` on `src/shared/components/layout/FloatingNavbar.tsx` to remove the hidden `layout-mode` button.
+   - Use `replace_with_git_merge_diff` on `src/shared/components/layout/FloatingNavbar.test.tsx` to remove the tests expecting `layout-mode` button.
+5. **Lint and Test**
+   - Run `pnpm dlx @biomejs/biome check --config-path config/biome.json --write src/` to ensure formatting.
+   - Run `pnpm test run` to verify tests pass.
+6. **Pre-commit Steps**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/src/app/routes/HomeRoute.tsx
+++ b/src/app/routes/HomeRoute.tsx
@@ -73,14 +73,6 @@ export default function HomeRoute() {
 								<TournamentFlow />
 							</Suspense>
 						</div>
-						<div className="mt-auto pt-8 flex justify-center gap-4">
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("")}>
-								← Back
-							</Button>
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								Compare →
-							</Button>
-						</div>
 					</div>
 				</div>
 			</Section>
@@ -103,26 +95,16 @@ export default function HomeRoute() {
 						</div>
 						<Suspense fallback={<Loading variant="skeleton" height={400} />}>
 							{tournament.names && tournament.names.length > 0 ? (
-								<>
-									<div className="w-full">
-										<LazyTournament
-											names={tournament.names}
-											existingRatings={tournament.ratings}
-											onComplete={(ratings) => {
-												tournamentActions.completeTournament(ratings);
-												scheduleAnalysisScroll();
-											}}
-										/>
-									</div>
-									<div className="mt-auto pt-8 flex justify-center gap-4">
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-											← Back
-										</Button>
-										<Button variant="glass" size="lg" onClick={() => scrollToSection("analysis")}>
-											See Results →
-										</Button>
-									</div>
-								</>
+								<div className="w-full">
+									<LazyTournament
+										names={tournament.names}
+										existingRatings={tournament.ratings}
+										onComplete={(ratings) => {
+											tournamentActions.completeTournament(ratings);
+											scheduleAnalysisScroll();
+										}}
+									/>
+								</div>
 							) : (
 								<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-6 py-12 text-center">
 									<p className="text-pretty text-sm text-muted-foreground/70">
@@ -166,14 +148,6 @@ export default function HomeRoute() {
 									/>
 								</ErrorBoundary>
 							</Suspense>
-						</div>
-						<div className="mt-auto pt-8 flex justify-center gap-4">
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("tournament")}>
-								← Back
-							</Button>
-							<Button variant="glass" size="lg" onClick={() => scrollToSection("pick")}>
-								Pick Different Names
-							</Button>
 						</div>
 					</div>
 				</div>

--- a/src/features/tournament/components/NameSelector.tsx
+++ b/src/features/tournament/components/NameSelector.tsx
@@ -1,6 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { AnimatePresence, motion, type PanInfo } from "framer-motion";
-import { Check, ChevronDown, ChevronRight, Eye, EyeOff, Heart, X, ZoomIn } from "lucide-react";
+import {
+	Check,
+	ChevronDown,
+	ChevronRight,
+	Eye,
+	EyeOff,
+	Heart,
+	Layers,
+	LayoutGrid,
+	X,
+	ZoomIn,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useToast } from "@/app/providers/Providers";
 import { namesQueryOptions } from "@/shared/api/names/api";
@@ -56,6 +67,7 @@ const EXIT_SPRING_CONFIG = {
 	velocity: 50,
 };
 
+import { MagicToggle } from "@/shared/components/ui/MagicToggle";
 import { AdminActionButton } from "./name-selector/AdminActionButton";
 import { NameContent } from "./name-selector/NameContent";
 import { getCardStyles, getNameOverlayClasses } from "./name-selector/nameSelectorUtils";
@@ -67,7 +79,7 @@ export function NameSelector() {
 	const toast = useToast();
 	const [selectedNames, setSelectedNames] = useState<Set<IdType>>(new Set());
 	const isSwipeMode = useAppStore((state) => state.ui.isSwipeMode);
-	const _setSwipeMode = useAppStore((state) => state.uiActions.setSwipeMode);
+	const setSwipeMode = useAppStore((state) => state.uiActions.setSwipeMode);
 	const isAdmin = useAppStore((state) => state.user.isAdmin);
 	const userName = useAppStore((state) => state.user.name);
 	const tournamentActions = useAppStore((state) => state.tournamentActions);
@@ -477,6 +489,18 @@ export function NameSelector() {
 	return (
 		<div className="mx-auto w-full">
 			<div className="space-y-4 sm:space-y-6 mobile-nav-safe-bottom">
+				<div className="flex justify-center pb-4 pt-2">
+					<MagicToggle
+						options={[
+							{ value: "swipe", label: "Swipe", icon: <Layers size={16} /> },
+							{ value: "grid", label: "Grid", icon: <LayoutGrid size={16} /> },
+						]}
+						value={isSwipeMode ? "swipe" : "grid"}
+						onChange={(v) => setSwipeMode(v === "swipe")}
+						ariaLabel="Select Layout Mode"
+					/>
+				</div>
+
 				{isSwipeMode ? (
 					<>
 						<div

--- a/src/shared/components/layout/FloatingNavbar.test.tsx
+++ b/src/shared/components/layout/FloatingNavbar.test.tsx
@@ -17,7 +17,6 @@ const queryClient = new QueryClient({
 	},
 });
 
-const setSwipeModeMock = vi.fn();
 const setNamesMock = vi.fn();
 
 const mockStore = {
@@ -35,12 +34,6 @@ const mockStore = {
 		name: "",
 		avatarUrl: "",
 		isAdmin: false,
-	},
-	ui: {
-		isSwipeMode: false,
-	},
-	uiActions: {
-		setSwipeMode: setSwipeModeMock,
 	},
 };
 
@@ -107,9 +100,7 @@ describe("FloatingNavbar", () => {
 		mockStore.user.name = "";
 		mockStore.user.avatarUrl = "";
 		mockStore.user.isAdmin = false;
-		mockStore.ui.isSwipeMode = false;
 
-		setSwipeModeMock.mockReset();
 		setNamesMock.mockReset();
 
 		Object.defineProperty(window, "matchMedia", {
@@ -228,24 +219,6 @@ describe("FloatingNavbar", () => {
 			"aria-current",
 			"location",
 		);
-	});
-
-	it("uses pressed semantics for the layout mode chip without treating it as the current destination", () => {
-		mountSections({ pick: 0, tournament: 200, analysis: 400 });
-		setPastHeroScroll();
-		mockStore.ui.isSwipeMode = true;
-
-		renderWithRouter();
-
-		expandNav();
-
-		const modeChip = screen.getAllByRole("button", { name: "Swipe mode active" })[0];
-
-		expect(modeChip).toHaveAttribute("aria-pressed", "true");
-		expect(modeChip).not.toHaveAttribute("aria-current");
-
-		fireEvent.click(modeChip);
-		expect(setSwipeModeMock).toHaveBeenCalledWith(false);
 	});
 
 	it("renders the logged-in avatar when available", () => {

--- a/src/shared/components/layout/FloatingNavbar.tsx
+++ b/src/shared/components/layout/FloatingNavbar.tsx
@@ -1,13 +1,4 @@
-import {
-	BarChart3,
-	CheckCircle,
-	Layers,
-	LayoutGrid,
-	Lightbulb,
-	Lock,
-	Trophy,
-	User,
-} from "lucide-react";
+import { BarChart3, CheckCircle, Lightbulb, Lock, Trophy, User } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/app/providers/Providers";
@@ -80,11 +71,9 @@ export function FloatingNavbar() {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const { login, logout } = useAuth();
-	const { tournament, tournamentActions, user, ui, uiActions } = appStore;
+	const { tournament, tournamentActions, user } = appStore;
 	const { selectedNames } = tournament;
 	const { isLoggedIn, name: userName, avatarUrl, isAdmin } = user;
-	const { isSwipeMode } = ui;
-	const { setSwipeMode } = uiActions;
 	const [activeSection, setActiveSection] = useState<NavSection>("pick");
 	const [isNavVisible, setIsNavVisible] = useState(true);
 	const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
@@ -440,21 +429,6 @@ export function FloatingNavbar() {
 			onClick: openProfileModal,
 		});
 
-		if (isHomeRoute) {
-			items.push({
-				id: "layout-mode",
-				label: isSwipeMode ? "Swipe mode" : "Grid mode",
-				level: 2,
-				icon: isSwipeMode ? <Layers className="h-4 w-4" /> : <LayoutGrid className="h-4 w-4" />,
-				ariaLabel: isSwipeMode ? "Swipe mode active" : "Grid mode active",
-				ariaPressed: isSwipeMode,
-				onClick: () => {
-					hapticNavTap();
-					setSwipeMode(!isSwipeMode);
-				},
-			});
-		}
-
 		return items;
 	}, [
 		activeSection,
@@ -468,13 +442,11 @@ export function FloatingNavbar() {
 		isLoggedIn,
 		isProfileOpen,
 		isSuggestOpen,
-		isSwipeMode,
 		isTournamentActive,
 		openProfileModal,
 		openSuggestModal,
 		profileLabel,
 		selectedCount,
-		setSwipeMode,
 		tournament.ratings,
 	]);
 

--- a/src/shared/components/ui/MagicToggle.tsx
+++ b/src/shared/components/ui/MagicToggle.tsx
@@ -1,0 +1,72 @@
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+import { hapticNavTap } from "@/shared/lib/browser/haptics";
+
+export interface MagicToggleOption<T extends string> {
+	value: T;
+	label: string;
+	icon?: ReactNode;
+}
+
+export interface MagicToggleProps<T extends string> {
+	options: readonly MagicToggleOption<T>[];
+	value: T;
+	onChange: (value: T) => void;
+	ariaLabel?: string;
+}
+
+export function MagicToggle<T extends string>({
+	options,
+	value,
+	onChange,
+	ariaLabel,
+}: MagicToggleProps<T>) {
+	return (
+		<div
+			className="relative inline-flex items-center p-1.5 bg-foreground/5 backdrop-blur-md rounded-2xl border border-border/20 shadow-inner"
+			role="tablist"
+			aria-label={ariaLabel}
+		>
+			<motion.div
+				className="absolute inset-y-1.5 bg-primary/15 border border-primary/20 rounded-xl shadow-[0_0_15px_rgba(var(--primary),0.1)] pointer-events-none"
+				initial={false}
+				animate={{
+					x: `calc(${options.findIndex((o) => o.value === value) * 100}% + ${options.findIndex((o) => o.value === value) * 4}px)`,
+					width: `calc(${100 / options.length}% - 4px)`,
+				}}
+				transition={{
+					type: "spring",
+					stiffness: 400,
+					damping: 25,
+					mass: 0.8,
+				}}
+			/>
+			{options.map((option) => {
+				const isSelected = value === option.value;
+				return (
+					<motion.button
+						key={option.value}
+						role="tab"
+						aria-selected={isSelected}
+						onClick={() => {
+							hapticNavTap();
+							onChange(option.value);
+						}}
+						className={`relative flex-1 px-5 py-2 sm:px-8 sm:py-2.5 text-xs sm:text-sm font-bold tracking-wide transition-colors z-10 rounded-xl ${
+							isSelected ? "text-primary" : "text-muted-foreground hover:text-foreground"
+						}`}
+						whileHover={{ scale: 1.05 }}
+						whileTap={{ scale: 0.95 }}
+					>
+						<div className="flex items-center justify-center gap-2">
+							{option.icon && (
+								<span className="flex items-center justify-center">{option.icon}</span>
+							)}
+							<span>{option.label}</span>
+						</div>
+					</motion.button>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/shared/components/ui/NavbarModals.tsx
+++ b/src/shared/components/ui/NavbarModals.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from "react";
-import { Modal } from "@/shared/components/layout/Modal";
 import { Loading } from "@/shared/components/layout/Feedback/Loading";
+import { Modal } from "@/shared/components/layout/Modal";
 
 const LazyProfileInner = lazy(() =>
 	import("@/shared/components/profile/ProfileInner").then((module) => ({

--- a/src/shared/components/ui/SegmentedControl.tsx
+++ b/src/shared/components/ui/SegmentedControl.tsx
@@ -71,8 +71,8 @@ export function SegmentedControl<T extends string = string>({
 					className={`relative flex-1 ${sizeStyles.button} text-foreground/70 transition-colors z-10 ${
 						value === option.value ? "text-foreground font-semibold" : ""
 					} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:text-foreground/90"}`}
-					whileHover={!disabled ? { scale: 1.02 } : {}}
-					whileTap={!disabled ? { scale: 0.98 } : {}}
+					whileHover={disabled ? {} : { scale: 1.02 }}
+					whileTap={disabled ? {} : { scale: 0.98 }}
 				>
 					<div className="flex items-center justify-center gap-1.5">
 						{option.icon && <span className="flex items-center justify-center">{option.icon}</span>}

--- a/src/shared/components/ui/SelectCombobox.tsx
+++ b/src/shared/components/ui/SelectCombobox.tsx
@@ -1,6 +1,6 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown, Search, X } from "lucide-react";
 import { type ChangeEvent, useCallback, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 
 interface SelectComboboxOption {
 	value: string;
@@ -60,11 +60,9 @@ export function SelectCombobox({
 					isOpen ? "border-primary/40 ring-2 ring-primary/10" : "hover:border-border/40"
 				} ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
 				whileHover={!disabled && !isOpen ? { borderColor: "var(--color-border)" } : {}}
-				whileTap={!disabled ? { scale: 0.98 } : {}}
+				whileTap={disabled ? {} : { scale: 0.98 }}
 			>
-				<span className="truncate text-foreground/80">
-					{selectedOption?.label || placeholder}
-				</span>
+				<span className="truncate text-foreground/80">{selectedOption?.label || placeholder}</span>
 				<motion.div
 					animate={{ rotate: isOpen ? 180 : 0 }}
 					transition={{ duration: 0.2 }}
@@ -91,13 +89,11 @@ export function SelectCombobox({
 								<div className="relative flex items-center">
 									<Search size={14} className="absolute left-2.5 text-foreground/40" />
 									<input
-										autoFocus
+										autoFocus={true}
 										type="text"
 										placeholder="Search..."
 										value={searchTerm}
-										onChange={(e: ChangeEvent<HTMLInputElement>) =>
-											setSearchTerm(e.target.value)
-										}
+										onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
 										onClick={(e) => e.stopPropagation()}
 										className="w-full pl-8 pr-3 py-1.5 text-xs bg-muted border border-border/20 rounded text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
 									/>

--- a/src/shared/hooks/useSectionScroll.ts
+++ b/src/shared/hooks/useSectionScroll.ts
@@ -6,7 +6,9 @@ export function useSectionScroll() {
 	const pendingScrollRef = useRef<number | null>(null);
 
 	const clearPendingScroll = useCallback(() => {
-		if (pendingScrollRef.current === null) return;
+		if (pendingScrollRef.current === null) {
+			return;
+		}
 		window.clearTimeout(pendingScrollRef.current);
 		pendingScrollRef.current = null;
 	}, []);

--- a/test-ui-prune.js
+++ b/test-ui-prune.js
@@ -1,0 +1,1 @@
+console.log("Checking for floating buttons and layout modes...")


### PR DESCRIPTION
Implements a batch UI prune to group scattered layout features and clean up the front page.

- Built a new `components/ui/MagicToggle.tsx` utilizing Framer Motion for playful interaction and ARIA tablist semantics for accessibility.
- Moved the Grid vs. Swipe layout toggle out of the hidden `FloatingNavbar` menu and directly into the `NameSelector.tsx` header where the context actually applies.
- Pruned redundant "Back" and "Compare" buttons at the bottom of the `HomeRoute.tsx` sections, as the `FloatingNavbar` already handles scrolling between sections continuously.
- Removed dead code and test assertions from `FloatingNavbar`.

---
*PR created automatically by Jules for task [13213665547694731922](https://jules.google.com/task/13213665547694731922) started by @guitarbeat*

## Summary by Sourcery

Group the layout mode toggle into a new contextual UI component and tidy the home page navigation.

New Features:
- Introduce a reusable MagicToggle UI component with animated, accessible tab-like behavior for switching modes.
- Expose the swipe vs grid layout toggle in the NameSelector header where it directly controls the tournament view.

Enhancements:
- Remove redundant Back/Compare navigation buttons from HomeRoute sections in favor of the FloatingNavbar controls.
- Prune layout-mode handling from FloatingNavbar and its tests now that layout switching is handled contextually in NameSelector.
- Apply minor UI and interaction cleanups in shared components, including motion props, event handlers, and scroll timeout handling.
- Add a small helper script and planning doc related to the UI pruning task.

Tests:
- Simplify FloatingNavbar tests by removing expectations around the now-deleted layout-mode control.