### PR TITLE
🧹 fix: remove stale ts-expect-error comments from ratingService

### DIFF
--- a/src/shared/services/supabase/ratingService.ts
+++ b/src/shared/services/supabase/ratingService.ts
@@ -14,7 +14,10 @@ const validateRatingsData = (
 	ratings: Record<string, { rating: number; wins: number; losses: number }>,
 ): { isValid: boolean; error?: string } => {
 	if (!userId || typeof userId !== "string" || userId.trim().length === 0) {
-		return { isValid: false, error: "Invalid userId: must be a non-empty string" };
+		return {
+			isValid: false,
+			error: "Invalid userId: must be a non-empty string",
+		};
 	}
 
 	if (!ratings || typeof ratings !== "object") {
@@ -26,35 +29,59 @@ const validateRatingsData = (
 	for (const nameId in ratings) {
 		ratingsCount++;
 		if (ratingsCount > 200) {
-			return { isValid: false, error: "Invalid ratings: exceeds maximum limit of 200 entries" };
+			return {
+				isValid: false,
+				error: "Invalid ratings: exceeds maximum limit of 200 entries",
+			};
 		}
 
 		const data = ratings[nameId];
 		if (!nameId || typeof nameId !== "string") {
-			return { isValid: false, error: "Invalid nameId: must be a non-empty string" };
+			return {
+				isValid: false,
+				error: "Invalid nameId: must be a non-empty string",
+			};
 		}
 
 		if (!data || typeof data !== "object") {
-			return { isValid: false, error: `Invalid rating data for ${nameId}: must be an object` };
+			return {
+				isValid: false,
+				error: `Invalid rating data for ${nameId}: must be an object`,
+			};
 		}
 
 		const { rating, wins, losses } = data;
 
-		if (typeof rating !== "number" || Number.isNaN(rating) || rating < 800 || rating > 2400) {
+		if (
+			typeof rating !== "number" ||
+			Number.isNaN(rating) ||
+			rating < 800 ||
+			rating > 2400
+		) {
 			return {
 				isValid: false,
 				error: `Invalid rating for ${nameId}: must be a number between 800 and 2400`,
 			};
 		}
 
-		if (typeof wins !== "number" || Number.isNaN(wins) || wins < 0 || wins > 1000) {
+		if (
+			typeof wins !== "number" ||
+			Number.isNaN(wins) ||
+			wins < 0 ||
+			wins > 1000
+		) {
 			return {
 				isValid: false,
 				error: `Invalid wins for ${nameId}: must be a number between 0 and 1000`,
 			};
 		}
 
-		if (typeof losses !== "number" || Number.isNaN(losses) || losses < 0 || losses > 1000) {
+		if (
+			typeof losses !== "number" ||
+			Number.isNaN(losses) ||
+			losses < 0 ||
+			losses > 1000
+		) {
 			return {
 				isValid: false,
 				error: `Invalid losses for ${nameId}: must be a number between 0 and 1000`,
@@ -77,7 +104,6 @@ export const ratingsAPI = {
 		winnerSide,
 	}: ApplyTournamentMatchParams) => {
 		return withSupabaseOrThrow(async (client) => {
-			// @ts-expect-error - apply_tournament_match_elo is a custom RPC not yet reflected in generated types
 			const { data, error } = await client.rpc("apply_tournament_match_elo", {
 				p_user_name: userName.trim(),
 				p_left_name_ids: leftNameIds,
@@ -130,7 +156,6 @@ export const ratingsAPI = {
 		}
 
 		return withSupabaseOrThrow(async (client) => {
-			// @ts-expect-error - save_user_ratings is a custom RPC not yet reflected in generated types
 			const { data, error } = await client.rpc("save_user_ratings", {
 				p_user_name: userId,
 				p_ratings: ratingsList,


### PR DESCRIPTION
🎯 **What:** Removed `// @ts-expect-error` comments in `ratingService.ts` for custom RPCs `save_user_ratings` and `apply_tournament_match_elo`.
💡 **Why:** These RPCs have since been reflected in the generated database types, making the suppression comments unnecessary and potentially masking future type errors.
✅ **Verification:** Type checking via `tsc --noEmit` passes locally, format checks pass, and tests execute without new failures.
✨ **Result:** A cleaner codebase with accurate typing for our Supabase services.

---
*PR created automatically by Jules for task [11102637303915967412](https://jules.google.com/task/11102637303915967412) started by @guitarbeat*

## Summary by Sourcery

Clean up Supabase rating service typings by relying on generated RPC types and improving validation readability.

Enhancements:
- Remove obsolete TypeScript suppression comments for custom Supabase RPCs now covered by generated types.
- Reformat and clarify rating validation logic for better readability without changing behavior.