### PR TITLE
feat: add aria-label to ProfileInner input component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-18 - Added Proper ARIA roles to custom Tab Navigation
 **Learning:** When building custom tab components from mapped arrays of button elements, using `role="tablist"`, `role="tab"`, and `aria-selected={condition}` is essential for proper screen reader communication and accessibility standards.
 **Action:** Always ensure mapped button lists acting as tabs in custom navigation components include these explicit ARIA roles.
+## 2026-06-21 - Adding aria-labels to Input components
+**Learning:** The custom `Input` component does not enforce accessible labels out-of-the-box, meaning consumers like `ProfileInner.tsx` which render inputs with only placeholder text are invisible to screen readers without an explicit `label` or `aria-label` prop.
+**Action:** Always explicitly verify that custom form fields, especially those lacking visual labels (relying only on icons and placeholders), include an `aria-label` or `aria-labelledby` prop to satisfy WCAG criteria and provide context to assistive technologies.

--- a/src/shared/components/profile/ProfileInner.tsx
+++ b/src/shared/components/profile/ProfileInner.tsx
@@ -10,13 +10,7 @@ interface ProfileInnerProps {
 	onLogout: () => Promise<void>;
 }
 
-function ProfileAvatar({
-	avatarSrc,
-	onError,
-}: {
-	avatarSrc: string;
-	onError: () => void;
-}) {
+function ProfileAvatar({ avatarSrc, onError }: { avatarSrc: string; onError: () => void }) {
 	return (
 		<div className="relative mb-1">
 			<div
@@ -24,12 +18,7 @@ function ProfileAvatar({
 				aria-hidden="true"
 			/>
 			<div className="relative size-24 rounded-full overflow-hidden ring-2 ring-primary/30 ring-offset-2 ring-offset-card bg-muted shadow-lg">
-				<img
-					src={avatarSrc}
-					alt="Profile"
-					className="size-full object-cover"
-					onError={onError}
-				/>
+				<img src={avatarSrc} alt="Profile" className="size-full object-cover" onError={onError} />
 			</div>
 		</div>
 	);
@@ -87,12 +76,7 @@ function ProfileEditForm({
 
 			<div className="flex gap-2">
 				{isLoggedIn && (
-					<Button
-						type="button"
-						variant="ghost"
-						onClick={handleCancel}
-						className="flex-1"
-					>
+					<Button type="button" variant="ghost" onClick={handleCancel} className="flex-1">
 						Cancel
 					</Button>
 				)}
@@ -119,12 +103,7 @@ interface ProfileViewProps {
 	handleLogout: () => void;
 }
 
-function ProfileView({
-	userName,
-	isLoggingOut,
-	handleEdit,
-	handleLogout,
-}: ProfileViewProps) {
+function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: ProfileViewProps) {
 	return (
 		<div className="w-full flex flex-col items-center gap-3 animate-in fade-in duration-200">
 			<div className="flex items-center gap-2">
@@ -139,9 +118,7 @@ function ProfileView({
 				</button>
 			</div>
 
-			<p className="text-xs text-muted-foreground/80">
-				Your preferences are saved for ranking.
-			</p>
+			<p className="text-xs text-muted-foreground/80">Your preferences are saved for ranking.</p>
 
 			<button
 				type="button"
@@ -228,10 +205,7 @@ export function ProfileInner({ onLogin, onLogout }: ProfileInnerProps) {
 
 	return (
 		<div className="flex flex-col items-center gap-5 w-full">
-			<ProfileAvatar
-				avatarSrc={avatarSrc}
-				onError={() => setAvatarSrc(defaultAvatar)}
-			/>
+			<ProfileAvatar avatarSrc={avatarSrc} onError={() => setAvatarSrc(defaultAvatar)} />
 
 			{isEditing ? (
 				<ProfileEditForm

--- a/src/shared/components/profile/ProfileInner.tsx
+++ b/src/shared/components/profile/ProfileInner.tsx
@@ -10,7 +10,13 @@ interface ProfileInnerProps {
 	onLogout: () => Promise<void>;
 }
 
-function ProfileAvatar({ avatarSrc, onError }: { avatarSrc: string; onError: () => void }) {
+function ProfileAvatar({
+	avatarSrc,
+	onError,
+}: {
+	avatarSrc: string;
+	onError: () => void;
+}) {
 	return (
 		<div className="relative mb-1">
 			<div
@@ -18,7 +24,12 @@ function ProfileAvatar({ avatarSrc, onError }: { avatarSrc: string; onError: () 
 				aria-hidden="true"
 			/>
 			<div className="relative size-24 rounded-full overflow-hidden ring-2 ring-primary/30 ring-offset-2 ring-offset-card bg-muted shadow-lg">
-				<img src={avatarSrc} alt="Profile" className="size-full object-cover" onError={onError} />
+				<img
+					src={avatarSrc}
+					alt="Profile"
+					className="size-full object-cover"
+					onError={onError}
+				/>
 			</div>
 		</div>
 	);
@@ -62,6 +73,7 @@ function ProfileEditForm({
 						}
 					}}
 					placeholder="Who are you?"
+					aria-label="Your name"
 					onKeyDown={(e) => e.key === "Enter" && handleSave()}
 					className="w-full h-11 pl-10 pr-4 text-sm"
 				/>
@@ -75,7 +87,12 @@ function ProfileEditForm({
 
 			<div className="flex gap-2">
 				{isLoggedIn && (
-					<Button type="button" variant="ghost" onClick={handleCancel} className="flex-1">
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={handleCancel}
+						className="flex-1"
+					>
 						Cancel
 					</Button>
 				)}
@@ -102,7 +119,12 @@ interface ProfileViewProps {
 	handleLogout: () => void;
 }
 
-function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: ProfileViewProps) {
+function ProfileView({
+	userName,
+	isLoggingOut,
+	handleEdit,
+	handleLogout,
+}: ProfileViewProps) {
 	return (
 		<div className="w-full flex flex-col items-center gap-3 animate-in fade-in duration-200">
 			<div className="flex items-center gap-2">
@@ -117,7 +139,9 @@ function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: Profi
 				</button>
 			</div>
 
-			<p className="text-xs text-muted-foreground/80">Your preferences are saved for ranking.</p>
+			<p className="text-xs text-muted-foreground/80">
+				Your preferences are saved for ranking.
+			</p>
 
 			<button
 				type="button"
@@ -204,7 +228,10 @@ export function ProfileInner({ onLogin, onLogout }: ProfileInnerProps) {
 
 	return (
 		<div className="flex flex-col items-center gap-5 w-full">
-			<ProfileAvatar avatarSrc={avatarSrc} onError={() => setAvatarSrc(defaultAvatar)} />
+			<ProfileAvatar
+				avatarSrc={avatarSrc}
+				onError={() => setAvatarSrc(defaultAvatar)}
+			/>
 
 			{isEditing ? (
 				<ProfileEditForm


### PR DESCRIPTION
💡 What: Added an `aria-label="Your name"` to the `Input` component in `ProfileInner.tsx`.
🎯 Why: The custom `Input` component used in `ProfileInner.tsx` relied entirely on a placeholder ("Who are you?") and an icon for context, leaving it inaccessible to screen readers without an explicit label. This simple addition ensures the field is semantically correct and usable by assistive technologies.
♿ Accessibility: Improves form field accessibility by providing a descriptive `aria-label` for screen readers.

---
*PR created automatically by Jules for task [6033503795487203934](https://jules.google.com/task/6033503795487203934) started by @guitarbeat*

## Summary by Sourcery

Improve accessibility of the profile name input and document accessibility learnings.

New Features:
- Add an aria-label to the profile name input to provide an accessible name for screen readers.

Documentation:
- Document accessibility considerations and best practices for adding aria-labels to custom Input components in the Jules palette notes.