### PR TITLE
perf: optimize max/min rating calculations to prevent stack overflows

### DIFF
--- a/src/features/dashboard/components/analytics/components/RatingDistributionChart.tsx
+++ b/src/features/dashboard/components/analytics/components/RatingDistributionChart.tsx
@@ -33,8 +33,15 @@ export function RatingDistributionChart({ leaderboard }: RatingDistributionChart
 			return [];
 		}
 
-		const minBucket = Math.floor(Math.min(...ratings) / BUCKET_SIZE) * BUCKET_SIZE;
-		const maxBucket = Math.ceil(Math.max(...ratings) / BUCKET_SIZE) * BUCKET_SIZE;
+		let minRating = Number.POSITIVE_INFINITY;
+		let maxRating = Number.NEGATIVE_INFINITY;
+		for (const r of ratings) {
+			if (r < minRating) minRating = r;
+			if (r > maxRating) maxRating = r;
+		}
+
+		const minBucket = Math.floor(minRating / BUCKET_SIZE) * BUCKET_SIZE;
+		const maxBucket = Math.ceil(maxRating / BUCKET_SIZE) * BUCKET_SIZE;
 
 		const buckets: Record<number, number> = {};
 		for (let b = minBucket; b <= maxBucket; b += BUCKET_SIZE) {
@@ -82,7 +89,7 @@ export function RatingDistributionChart({ leaderboard }: RatingDistributionChart
 	}
 
 	const meanRange = meanBucket === null ? null : bucketLabel(meanBucket);
-	const maxCount = Math.max(...data.map((d) => d.count));
+	const maxCount = data.reduce((max, d) => Math.max(max, d.count), 0);
 
 	return (
 		<div className="space-y-3">


### PR DESCRIPTION
💡 **What**:
Optimized `RatingDistributionChart.tsx` to calculate min/max bucket thresholds and chart maximums without using spread operators on large, dynamically sized arrays.

🎯 **Why**:
Using `Math.min(...array)` or `Math.max(...array)` on very large arrays (like an extended user leaderboard or long activity history) can trigger a "Maximum call stack size exceeded" error because JavaScript engines limit the number of arguments passed to a function. In addition, mapping to a new array and then spreading it is memory-inefficient.

📊 **Impact**:
- Eliminates the risk of stack overflow crashes when the leaderboard has many ratings.
- Combines two O(N) operations (`Math.min` and `Math.max`) into a single O(N) `for` loop, improving computational efficiency.
- Reduces memory allocation overhead by using `reduce` instead of `.map().spread`.

🔬 **Measurement**:
Calculations remain mathematically identical, but the `for` loop handles arrays of any size without triggering engine limits. Run `pnpm test run` to verify that no regressions were introduced.

---
*PR created automatically by Jules for task [1802392864356047686](https://jules.google.com/task/1802392864356047686) started by @guitarbeat*

## Summary by Sourcery

Optimize rating distribution chart min/max calculations to avoid stack overflows on large datasets and improve performance.

Bug Fixes:
- Prevent potential maximum call stack size exceeded errors when computing rating buckets from large rating arrays.

Enhancements:
- Replace spread-based min/max rating computations with a single pass loop to reduce time and memory overhead in rating bucket calculation.
- Compute maximum bucket count using a reduction instead of mapping and spreading to improve efficiency for large rating datasets.