### PR TITLE
feat: add loading state and aria-busy to logout button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2026-06-18 - Added Proper ARIA roles to custom Tab Navigation
-**Learning:** When building custom tab components from mapped arrays of button elements, using `role="tablist"`, `role="tab"`, and `aria-selected={condition}` is essential for proper screen reader communication and accessibility standards.
-**Action:** Always ensure mapped button lists acting as tabs in custom navigation components include these explicit ARIA roles.
+## 2024-06-19 - Adding loading states to destructive/logout actions
+**Learning:** Adding a spinner to the logout button makes the UI feel more responsive during state transitions, and `aria-busy` is a simple but critical attribute for screen readers to understand an action is pending.
+**Action:** When creating form submissions or auth actions, ensure an `aria-busy` state and loading indicator are added.

--- a/src/shared/components/profile/ProfileInner.tsx
+++ b/src/shared/components/profile/ProfileInner.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Pencil, User } from "lucide-react";
+import { Loader2, LogOut, Pencil, User } from "lucide-react";
 import { type RefObject, useEffect, useRef, useState } from "react";
 import Button from "@/shared/components/layout/Button";
 import { Input } from "@/shared/components/layout/FormPrimitives";
@@ -123,9 +123,14 @@ function ProfileView({ userName, isLoggingOut, handleEdit, handleLogout }: Profi
 				type="button"
 				onClick={handleLogout}
 				disabled={isLoggingOut}
+				aria-busy={isLoggingOut}
 				className="mt-1 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-destructive/70 hover:text-destructive hover:bg-destructive/10 transition-colors"
 			>
-				<LogOut size={13} />
+				{isLoggingOut ? (
+					<Loader2 size={13} className="animate-spin" aria-hidden="true" />
+				) : (
+					<LogOut size={13} aria-hidden="true" />
+				)}
 				{isLoggingOut ? "Logging out..." : "Logout"}
 			</button>
 		</div>


### PR DESCRIPTION
💡 What: Added a visual loading spinner (`Loader2` from `lucide-react`) and an `aria-busy` attribute to the logout button when the `isLoggingOut` state is true.

🎯 Why: To improve the user experience during the async logout process by providing clear visual feedback that an action is occurring, and making it accessible to screen readers via `aria-busy`.

📸 Before/After: The button previously only changed its text from "Logout" to "Logging out...". Now it also features a spinning loader icon in place of the static `LogOut` icon while the action is pending.

♿ Accessibility: The addition of `aria-busy={isLoggingOut}` ensures screen readers are explicitly aware that the element is in a busy/loading state. `aria-hidden="true"` is also used on the icons to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [6850385843071226415](https://jules.google.com/task/6850385843071226415) started by @guitarbeat*

## Summary by Sourcery

Add a loading state and accessibility improvements to the profile logout button.

New Features:
- Show a loading spinner on the profile logout button while a logout action is in progress.

Enhancements:
- Mark the logout button as busy via aria-busy during logout and hide decorative icons from screen readers for better accessibility.
- Update the internal Jules palette notes to document guidance on adding loading states and aria-busy to destructive or auth-related actions.